### PR TITLE
Refactor HowItWorks: fix layout, responsive title, remove stepVisual …

### DIFF
--- a/app/components/HowItWorks/HowItWorks.module.css
+++ b/app/components/HowItWorks/HowItWorks.module.css
@@ -23,7 +23,7 @@
 
 .header {
   position: absolute;
-  top: 4rem;
+  top: 6rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 4rem;
@@ -42,7 +42,7 @@
 
 .title {
   font-family: var(--font-heading);
-  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-size: 5rem;
   font-weight: 800;
   color: #1f2937;
   line-height: 1.1;
@@ -349,7 +349,6 @@
     position: relative;
     top: 0;
     padding: 2rem 0;
-    margin-bottom: 2rem;
   }
   
   .stepContent {
@@ -372,11 +371,15 @@
   
   .header {
     grid-template-columns: 1fr;
-    gap: 1.5rem;
+    gap: 0.5rem;
     text-align: center;
     padding: 2rem 1rem 1rem;
     position: relative;
     top: auto;
+  }
+  
+  .title {
+    font-size: 4rem;
   }
   
   .stepsContainer {
@@ -438,8 +441,9 @@
 @media (max-width: 768px) {
   .stepImage {
     object-fit: contain;
-    width: 100%;
+    width: auto;
     height: 100%;
+    border-radius: 0;
   }
   
   .stepImageContainer {
@@ -454,7 +458,7 @@
   }
   
   .title {
-    font-size: 2rem;
+    font-size: 3rem;
   }
   
   .subtitle {
@@ -468,7 +472,7 @@
   }
   
   .stepContent {
-    gap: 1rem;
+    gap: 0rem;
     padding: 0.75rem;
   }
   

--- a/app/components/HowItWorks/HowItWorks.tsx
+++ b/app/components/HowItWorks/HowItWorks.tsx
@@ -299,14 +299,7 @@ export default function HowItWorks(): React.JSX.Element {
         {/* Header */}
         <div className={`${styles.header} grid grid-cols-1 lg:grid-cols-2 gap-16 mb-4 items-start`}>
           <div className="how-it-works-left">
-            <h2 className={`${styles.title} font-heading font-extrabold leading-tight`}
-                style={{
-                  fontSize: '4rem',
-                  background: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-secondary) 100%)',
-                  WebkitBackgroundClip: 'text',
-                  WebkitTextFillColor: 'transparent',
-                  backgroundClip: 'text'
-                }}>
+            <h2 className={`${styles.title} font-heading font-extrabold leading-tight`}>
               How it Works
             </h2>
           </div>
@@ -344,13 +337,14 @@ export default function HowItWorks(): React.JSX.Element {
                 
                 {/* Step Info */}
                 <div className={`${styles.stepInfo}`}>
-                  <div className={styles.stepNumber}>
-                    {step.number}
+                  <div className={styles.stepHeader}>
+                    <div className={styles.stepNumber}>
+                      {step.number}
+                    </div>
+                    <h3 className={styles.stepTitle}>
+                      {step.title}
+                    </h3>
                   </div>
-                  
-                  <h3 className={styles.stepTitle}>
-                    {step.title}
-                  </h3>
                   
                   <p className={styles.stepDescription}>
                     {step.description}
@@ -358,32 +352,30 @@ export default function HowItWorks(): React.JSX.Element {
                 </div>
 
                 {/* Step Visual */}
-                <div className={styles.stepVisual}>
-                  <div className={styles.stepImageContainer}>
-                    {step.media.type === 'video' ? (
-                      <video 
-                        key={step.media.src}
-                        className={styles.stepImage}
-                        autoPlay 
-                        muted 
-                        loop 
-                        playsInline
-                      >
-                        <source src={step.media.src} type="video/mp4" />
-                        <div className="flex items-center justify-center h-full bg-gray-200">
-                          <p className="text-gray-500">Video: {step.title}</p>
-                        </div>
-                      </video>
-                    ) : (
-                      <img 
-                        key={step.media.src}
-                        src={step.media.src} 
-                        alt={step.media.alt || step.title} 
-                        className={styles.stepImage}
-                        loading="lazy"
-                      />
-                    )}
-                  </div>
+                <div className={styles.stepImageContainer}>
+                  {step.media.type === 'video' ? (
+                    <video 
+                      key={step.media.src}
+                      className={styles.stepImage}
+                      autoPlay 
+                      muted 
+                      loop 
+                      playsInline
+                    >
+                      <source src={step.media.src} type="video/mp4" />
+                      <div className="flex items-center justify-center h-full bg-gray-200">
+                        <p className="text-gray-500">Video: {step.title}</p>
+                      </div>
+                    </video>
+                  ) : (
+                    <img 
+                      key={step.media.src}
+                      src={step.media.src} 
+                      alt={step.media.alt || step.title} 
+                      className={styles.stepImage}
+                      loading="lazy"
+                    />
+                  )}
                 </div>
                 
               </div>


### PR DESCRIPTION
…wrapper

- Put step number beside h3 title on same line for both desktop and mobile
- Remove stepVisual wrapper, simplify to stepImageContainer only
- Fix responsive title font sizes: 5rem desktop, 3rem mobile, 4rem tablet
- Remove inline CSS styles, move all styling to CSS modules
- Improve spacing and layout between text and media content