### PR TITLE
fix: Resolve center image stretching in ProductFeatures section

### DIFF
--- a/app/components/ProductFeatures/ProductFeatures.module.css
+++ b/app/components/ProductFeatures/ProductFeatures.module.css
@@ -20,7 +20,11 @@
 }
 
 .productCenter {
-  height: 350px !important;
+  max-width: 350px;
+  max-height: 350px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 
 .productFeatures {

--- a/app/components/ProductFeatures/ProductFeatures.tsx
+++ b/app/components/ProductFeatures/ProductFeatures.tsx
@@ -45,8 +45,8 @@ export default function ProductFeatures({ product }: ProductFeaturesProps) {
             className={styles.productCenter} 
             src={features.centerImage?.url} 
             alt={features.centerImage?.alt}
-            width={300}
-            height={300}
+            width={350}
+            height={350}
           />
         </div>
         <div className={styles.featuresContainer}>
@@ -71,8 +71,8 @@ export default function ProductFeatures({ product }: ProductFeaturesProps) {
             className={styles.productCenter} 
             src={features.centerImage?.url} 
             alt={features.centerImage?.alt}
-            width={300}
-            height={300}
+            width={350}
+            height={350}
           />
         </div>
         <div className={styles.featureHolderMobile}>


### PR DESCRIPTION
🎨 Image Display Fix:
- Replace fixed height (350px important) with responsive max-width/max-height constraints
- Add object-fit: contain to maintain proper aspect ratio
- Update Image component dimensions from 300x300 to 350x350 to match CSS constraints
- Apply width: auto and height: auto for natural scaling
- Fix applied to both desktop and mobile layouts

✅ No more stretched/distorted center image
✅ Maintains proper image proportions
✅ Responsive design preserved