### PR TITLE
Fix HowItWorks section layout overlap issue

### DIFF
--- a/app/components/HowItWorks/HowItWorks.module.css
+++ b/app/components/HowItWorks/HowItWorks.module.css
@@ -17,21 +17,21 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   padding: 0 2rem;
 }
 
 .header {
-  position: absolute;
-  top: 6rem;
+  position: relative;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 4rem;
   z-index: 20;
-  margin: 0 auto;
+  margin: 0 auto 2rem auto;
   max-width: 1400px;
   opacity: 0;
   animation: fadeIn 1s ease forwards;
+  padding-top: clamp(2rem, 8vh, 6rem);
 }
 
 @keyframes fadeIn {
@@ -82,8 +82,9 @@
 .stepsContainer {
   position: relative;
   width: 100%;
-  height: 100vh;
+  flex: 1;
   overflow: hidden;
+  min-height: 0;
 }
 
 .stepsWrapper {
@@ -532,6 +533,23 @@
     .stepsContainer {
       height: calc(-webkit-fill-available - 100px);
     }
+  }
+}
+
+/* Height-specific responsive adjustments for desktop */
+@media (min-width: 769px) and (max-height: 700px) {
+  .header {
+    padding-top: 1.5rem;
+    gap: 2rem;
+    margin-bottom: 1rem;
+  }
+  
+  .title {
+    font-size: 3.5rem;
+  }
+  
+  .subtitle {
+    font-size: 1rem;
   }
 }
 

--- a/app/components/HowItWorks/HowItWorks.tsx
+++ b/app/components/HowItWorks/HowItWorks.tsx
@@ -288,16 +288,16 @@ export default function HowItWorks(): React.JSX.Element {
     <section 
       ref={sectionRef}
       id="how-it-works-section" 
-      className={`${styles.section} relative w-full overflow-hidden py-32`}
+      className={styles.section}
       style={{
         minHeight: '100vh',
         background: 'linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%)'
       }}
     >
-      <div className={`${styles.container} mx-auto px-8`} style={{ maxWidth: '1400px' }}>
+      <div className={styles.container}>
         
         {/* Header */}
-        <div className={`${styles.header} grid grid-cols-1 lg:grid-cols-2 gap-16 mb-4 items-start`}>
+        <div className={styles.header}>
           <div className="how-it-works-left">
             <h2 className={`${styles.title} font-heading font-extrabold leading-tight`}>
               How it Works
@@ -333,7 +333,7 @@ export default function HowItWorks(): React.JSX.Element {
                   pointerEvents: index === currentStepIndex ? 'auto' : 'none'
                 }}
               >
-                <div className={`${styles.stepContent} grid grid-cols-1 lg:grid-cols-2 gap-16 h-full items-center`}>
+                <div className={styles.stepContent}>
                 
                 {/* Step Info */}
                 <div className={`${styles.stepInfo}`}>


### PR DESCRIPTION
- Remove conflicting Tailwind classes that were overriding CSS modules
- Fix header text overlapping step images by using pure CSS modules layout
- Change container from justify-content: center to flex-start for proper flow
- Convert steps container to use flex: 1 instead of fixed height calculations
- Remove redundant grid and spacing utility classes from JSX
- Ensure CSS modules handle all layout positioning consistently

Resolves text-over-image overlap in How It Works section