### PR TITLE
feat: Add comprehensive service pages system with Sanity CMS integration

### DIFF
--- a/app/(site)/services/[service]/page.tsx
+++ b/app/(site)/services/[service]/page.tsx
@@ -1,0 +1,115 @@
+import { getService, getServices } from '@/sanity/sanity-utils'
+import { Service } from '@/types/Service'
+import { notFound } from 'next/navigation'
+import { Metadata } from 'next'
+import Breadcrumb from '@/app/components/Breadcrumb/Breadcrumb'
+import ServiceHero from '@/app/components/ServiceHero/ServiceHero'
+import ServiceFeaturesOverview from '@/app/components/ServiceFeaturesOverview/ServiceFeaturesOverview'
+import ServiceValue from '@/app/components/ServiceValue/ServiceValue'
+import ServiceSpecialties from '@/app/components/ServiceSpecialties/ServiceSpecialties'
+import ServiceProcess from '@/app/components/ServiceProcess/ServiceProcess'
+import ServiceCTARow from '@/app/components/ServiceCTARow/ServiceCTARow'
+import ServiceProductRange from '@/app/components/ServiceProductRange/ServiceProductRange'
+import ServiceMiddleCTA from '@/app/components/ServiceMiddleCTA/ServiceMiddleCTA'
+import ServiceFAQ from '@/app/components/ServiceFAQ/ServiceFAQ'
+
+type Props = {
+  params: Promise<{ service: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { service: serviceSlug } = await params
+  const service = await getService(serviceSlug)
+  
+  if (!service) {
+    return {
+      title: 'Service Not Found',
+      description: 'The requested service could not be found.'
+    }
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.elixderm.com'
+  
+  // Get the hero image as OG image
+  const ogImage = service.hero?.image
+  const ogImageAlt = service.hero?.imageAlt || `${service.name} service image`
+  
+  return {
+    title: service.seo?.metaTitle || service.name,
+    description: service.seo?.metaDescription || `Learn more about ${service.name}`,
+    robots: {
+      index: !service.seo?.noIndex,
+      follow: !service.seo?.noIndex,
+    },
+    openGraph: {
+      title: service.seo?.metaTitle || service.name,
+      description: service.seo?.metaDescription || `Learn more about ${service.name}`,
+      url: `${baseUrl}/services/${service.slug}`,
+      siteName: 'Elixderm',
+      type: 'website',
+      images: ogImage ? [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: ogImageAlt,
+        }
+      ] : [],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: service.seo?.metaTitle || service.name,
+      description: service.seo?.metaDescription || `Learn more about ${service.name}`,
+      images: ogImage ? [
+        {
+          url: ogImage,
+          alt: ogImageAlt,
+        }
+      ] : [],
+    },
+    alternates: {
+      canonical: `${baseUrl}/services/${service.slug}`,
+    },
+  }
+}
+
+export default async function ServicePage({ params }: Props) {
+  const { service: serviceSlug } = await params
+  const service = await getService(serviceSlug)
+
+  if (!service) {
+    return notFound()
+  }
+
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Services', href: '/services' },
+    { label: service.name }
+  ]
+
+  return (
+    <div className="service-page">
+      <Breadcrumb items={breadcrumbItems} />
+      
+      <main className="service-page-main" style={{ maxWidth: '1400px', margin: '0 auto' }}>
+        <ServiceHero service={service} />
+        <ServiceFeaturesOverview service={service} />
+        <ServiceValue service={service} />
+        <ServiceSpecialties service={service} />
+        <ServiceProcess service={service} />
+        <ServiceCTARow service={service} type="top" />
+        <ServiceProductRange service={service} />
+        <ServiceMiddleCTA service={service} />
+        <ServiceFAQ service={service} />
+        <ServiceCTARow service={service} type="bottom" />
+      </main>
+    </div>
+  )
+}
+
+export async function generateStaticParams() {
+  const services = await getServices()
+  return services.map((service) => ({
+    service: service.slug,
+  }))
+}

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { getServices } from '@/sanity/sanity-utils'
+import { Service } from '@/types/Service'
+import Link from 'next/link'
+import Image from 'next/image'
+import Breadcrumb from '@/app/components/Breadcrumb/Breadcrumb'
+import PageHero from '@/app/components/PageHero/PageHero'
+import { useEffect, useState } from 'react'
+
+export default function ServicesPage() {
+  const [services, setServices] = useState<Service[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    // Set metadata
+    document.title = 'Our Services | Elixderm'
+    const metaDescription = document.querySelector('meta[name="description"]')
+    if (metaDescription) {
+      metaDescription.setAttribute('content', 'Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life.')
+    }
+
+    // Fetch services
+    getServices().then((data) => {
+      setServices(data)
+      setLoading(false)
+    })
+  }, [])
+
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Services' }
+  ]
+
+  // Group services by category
+  const groupedServices = services.reduce((acc, service) => {
+    const category = service.category || 'other'
+    if (!acc[category]) {
+      acc[category] = []
+    }
+    acc[category].push(service)
+    return acc
+  }, {} as Record<string, Service[]>)
+
+  const categoryLabels: Record<string, string> = {
+    formulation: 'Formulation Services',
+    research: 'Research & Development',
+    testing: 'Testing & Analysis',
+    consulting: 'Consulting',
+    other: 'Other Services'
+  }
+
+  if (loading) {
+    return (
+      <div className="services-page">
+        <Breadcrumb items={breadcrumbItems} />
+        <PageHero 
+          title="Our Services"
+          subtitle="Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life."
+        />
+        <main className="services-main" style={{ maxWidth: '1400px', margin: '0 auto', padding: '2rem', textAlign: 'center' }}>
+          <p>Loading services...</p>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="services-page">
+      <Breadcrumb items={breadcrumbItems} />
+      
+      <PageHero 
+        title="Our Services"
+        subtitle="Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life."
+      />
+      
+      <main className="services-main" style={{ maxWidth: '1400px', margin: '0 auto', padding: '2rem' }}>
+        {Object.entries(groupedServices).map(([category, categoryServices]) => (
+          <section key={category} style={{ marginBottom: '4rem' }}>
+            <h2 style={{ 
+              fontSize: '2rem', 
+              marginBottom: '2rem', 
+              color: '#1d413c',
+              textAlign: 'center'
+            }}>
+              {categoryLabels[category] || 'Services'}
+            </h2>
+            
+            <div style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+              gap: '2rem',
+              marginBottom: '3rem'
+            }}>
+              {categoryServices.map((service) => (
+                <Link 
+                  key={service._id}
+                  href={`/services/${service.slug}`}
+                  style={{
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    border: '1px solid #e4e6e8',
+                    borderRadius: '15px',
+                    overflow: 'hidden',
+                    transition: 'transform 0.3s ease, box-shadow 0.3s ease',
+                    display: 'block'
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.transform = 'translateY(-5px)'
+                    e.currentTarget.style.boxShadow = '0 10px 25px rgba(29, 65, 60, 0.1)'
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.transform = 'translateY(0)'
+                    e.currentTarget.style.boxShadow = 'none'
+                  }}
+                >
+                  <div>
+                    {service.hero?.image && (
+                      <div style={{ height: '200px', overflow: 'hidden' }}>
+                        <Image
+                          src={service.hero.image}
+                          alt={service.hero.imageAlt || service.name}
+                          width={400}
+                          height={200}
+                          style={{
+                            width: '100%',
+                            height: '100%',
+                            objectFit: 'cover'
+                          }}
+                        />
+                      </div>
+                    )}
+                    
+                    <div style={{ padding: '1.5rem' }}>
+                      <h3 style={{
+                        fontSize: '1.5rem',
+                        marginBottom: '1rem',
+                        color: '#1d413c'
+                      }}>
+                        {service.name}
+                      </h3>
+                      
+                      {service.hero?.description && (
+                        <p style={{
+                          color: '#666',
+                          lineHeight: '1.6',
+                          marginBottom: '1rem'
+                        }}>
+                          {service.hero.description.substring(0, 150)}
+                          {service.hero.description.length > 150 ? '...' : ''}
+                        </p>
+                      )}
+                      
+                      <span style={{
+                        color: '#1d413c',
+                        fontWeight: 'bold',
+                        fontSize: '1rem'
+                      }}>
+                        Learn More →
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ))}
+        
+        {services.length === 0 && (
+          <div style={{ textAlign: 'center', padding: '4rem 0' }}>
+            <h3 style={{ color: '#666' }}>No services available at the moment.</h3>
+            <p style={{ color: '#999' }}>Please check back later for updates.</p>
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/(site)/sitemap/page.tsx
+++ b/app/(site)/sitemap/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import Breadcrumb from "@/app/components/Breadcrumb";
 import PageHero from "@/app/components/PageHero";
-import { getProducts } from "@/sanity/sanity-utils";
+import { getProducts, getServices } from "@/sanity/sanity-utils";
 import { getProjects } from "@/sanity/sanity-utils";
 import { createClient } from "next-sanity";
 import { Product } from "@/types/Product";
 import { Project } from "@/types/project";
+import { Service } from "@/types/Service";
 
 type Page = {
   _id: string;
@@ -27,9 +28,10 @@ export default async function Sitemap() {
   ];
 
   // Fetch dynamic content from Sanity
-  const [products, projects, pages] = await Promise.all([
+  const [products, projects, services, pages] = await Promise.all([
     getProducts(),
     getProjects(),
+    getServices(),
     client.fetch(`*[_type == "page" && defined(slug.current)] {
       _id,
       title,
@@ -96,6 +98,35 @@ export default async function Sitemap() {
                     </span>
                     <span className="flex-1">
                       {product.name}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Services Section */}
+          {services && services.length > 0 && (
+            <div className="mb-16">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4">
+                Our Services
+              </h2>
+              <p className="text-gray-600 mb-8">
+                Comprehensive cosmetic manufacturing and development services for your brand.
+              </p>
+              
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-6 md:gap-y-4">
+                {services.map((service: Service) => (
+                  <Link 
+                    key={service._id}
+                    href={`/services/${service.slug}`} 
+                    className="flex items-start text-emerald-600 hover:text-emerald-700 text-lg group"
+                  >
+                    <span className="text-emerald-500 mr-3 mt-1 text-sm group-hover:text-emerald-600 transition-colors">
+                      •
+                    </span>
+                    <span className="flex-1">
+                      {service.name}
                     </span>
                   </Link>
                 ))}

--- a/app/components/ServiceCTARow/ServiceCTARow.module.css
+++ b/app/components/ServiceCTARow/ServiceCTARow.module.css
@@ -1,0 +1,152 @@
+/* Service CTA Row Styles */
+
+.ctaRow {
+  background-color: #10b981;
+  height: 100px;
+  display: flex;
+  color: white;
+  font-size: 25px;
+  padding: 2% 8%;
+  justify-content: space-around;
+  align-items: center;
+  cursor: pointer;
+  transition: 0.3s;
+  margin-top: 40px;
+}
+
+.ctaRow2 {
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  cursor: pointer;
+  transition: 0.3s;
+  margin-top: 40px;
+}
+
+.ctaContainer {
+  max-width: 1400px;
+  margin: 0 auto;
+  height: 100px;
+  display: flex;
+  color: white;
+  font-size: 25px;
+  justify-content: space-around;
+  align-items: center;
+  padding: 0 2rem;
+}
+
+.ctaRow:hover {
+  background-color: #fff;
+  height: 100px;
+  display: flex;
+  color: #059669;
+  padding: 2% 8%;
+  justify-content: space-around;
+  align-items: center;
+  cursor: pointer;
+  transition: 0.5s;
+  border-top: 2px solid #059669;
+  border-bottom: 2px solid #059669;
+}
+
+.ctaRow2:hover {
+  background: var(--color-light);
+  transition: 0.5s;
+  border-top: 2px solid #059669;
+  border-bottom: 2px solid #059669;
+}
+
+.ctaRow2:hover .ctaContainer {
+  color: #059669;
+}
+
+.ctaRow2:hover .ctaRowButton {
+  background-color: #059669 !important;
+  color: white !important;
+  transition: 0.3s;
+}
+
+.ctaRow2 p, .ctaRow2 button {
+  margin: 0px !important;
+}
+
+.ctaRow svg {
+  width: 100px;
+  transition: 0.3s;
+}
+
+.ctaRow:hover svg {
+  width: 120px;
+  transition: 0.3s;
+  stroke: #059669;
+  fill: #059669;
+}
+
+.ctaRow:hover svg g line,
+.ctaRow:hover svg defs marker polygon {
+  width: 120px;
+  transition: 0.3s;
+  stroke: #059669;
+  fill: #059669;
+}
+
+.ctaRow2 p {
+  font-size: 1.5rem; /* 24px */
+  font-family: var(--font-heading);
+}
+
+.ctaRowButton {
+  border: none;
+  cursor: pointer;
+  background-color: #fff !important;
+  color: #059669 !important;
+  padding: 10px 45px;
+  border-radius: 30px;
+  transition: 0.3s;
+  font-size: 1.125rem; /* 18px */
+}
+
+.ctaRow p {
+  margin: 0;
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .ctaRow p {
+    font-size: 1.125rem; /* 18px on mobile */
+    width: 90%;
+    line-height: 1.3;
+  }
+
+  .ctaRow2 p {
+    font-size: 1.125rem; /* 18px on mobile */
+    font-family: var(--font-heading);
+    width: 90%;
+    line-height: 1.3;
+    text-align: center;
+  }
+
+  .ctaRow2 {
+    flex-direction: column;
+    height: auto;
+    padding: 30px 0;
+  }
+
+  .ctaRow2:hover .ctaContainer {
+    padding-bottom: 30px;
+  }
+
+  .ctaRowButton {
+    width: 70%;
+    margin-top: 3% !important;
+    font-size: 15px;
+  }
+
+  .ctaRow2 p, .ctaRow2 button {
+    margin: 15px !important;
+  }
+}

--- a/app/components/ServiceCTARow/ServiceCTARow.tsx
+++ b/app/components/ServiceCTARow/ServiceCTARow.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+import styles from './ServiceCTARow.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceCTARowProps {
+  service: Service
+  type?: 'top' | 'bottom'
+}
+
+export default function ServiceCTARow({ service, type = 'top' }: ServiceCTARowProps) {
+  if (type === 'bottom') {
+    const ctaData = service?.bottomCTA
+    if (!ctaData) {
+      return null
+    }
+
+    return (
+      <Link href={ctaData.url || '/contact-us'} target="_blank">
+        <section className={styles.ctaRow2}>
+          <div className={styles.ctaContainer}>
+            <p>{ctaData.text}</p>
+            <button className={styles.ctaRowButton}>
+              {ctaData.buttonText || 'Book a Call Now!'}
+            </button>
+          </div>
+        </section>
+      </Link>
+    )
+  }
+
+  const ctaData = service?.topCTA
+  if (!ctaData) {
+    return null
+  }
+
+  return (
+    <Link href={ctaData.url || '/contact-us'} target="_blank">
+      <section className={styles.ctaRow}>
+        <p>{ctaData.text}</p>
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 800 800">
+          <g strokeWidth="9" stroke="hsl(0, 0%, 100%)" fill="none" strokeLinecap="round" strokeLinejoin="round" transform="rotate(315, 400, 400)">
+            <line x1="175" y1="175" x2="625" y2="625" markerEnd="url(#SvgjsMarker1748)"></line>
+          </g>
+          <defs>
+            <marker markerWidth="15" markerHeight="15" refX="7.5" refY="7.5" viewBox="0 0 15 15" orient="auto" id="SvgjsMarker1748">
+              <polygon points="0,15 7.5,7.5 0,0 15,7.5" fill="hsl(0, 0%, 100%)"></polygon>
+            </marker>
+          </defs>
+        </svg>
+      </section>
+    </Link>
+  )
+}

--- a/app/components/ServiceFAQ/ServiceFAQ.module.css
+++ b/app/components/ServiceFAQ/ServiceFAQ.module.css
@@ -1,0 +1,93 @@
+/* Service FAQ Styles */
+
+.faqContainer {
+  max-width: 800px;
+  margin: auto;
+  padding: 20px;
+}
+
+.faqTitle {
+  text-align: center;
+}
+
+.faqTitle h2 {
+  font-size: 2.5rem; /* 40px */
+  margin-bottom: 15px;
+}
+
+.faqTitle p {
+  font-size: 1.125rem; /* 18px */
+}
+
+.faqAccordion {
+  display: flex;
+  flex-direction: column;
+}
+
+.faqItem {
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.faqItem.active {
+  border-bottom: 2px solid #10b981;
+}
+
+.faqQuestion {
+  width: 100%;
+  text-align: left;
+  border: none;
+  padding: 30px;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 16px !important;
+  margin-bottom: 0 !important;
+  color: #626262;
+}
+
+.faqAnswer {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.4s ease;
+  padding: 0 0 0px 75px;
+}
+
+.faqItem.active .faqAnswer {
+  max-height: 200px;
+  padding: 0 0 30px 75px;
+  margin-bottom: 20px;
+}
+
+.toggleIcon {
+  display: inline-block;
+  transition: 0.3s ease;
+  background: #e4e6e8;
+  font-weight: 200;
+  font-size: 20px;
+  margin-right: 10px;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  text-align: center;
+  line-height: 28px;
+}
+
+.answerContent {
+  font-size: 1.125rem; /* 18px */
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .faqTitle h2 {
+    font-size: 1.5625rem; /* 25px */
+  }
+  
+  .faqTitle p {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+  
+  .answerContent {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+}

--- a/app/components/ServiceFAQ/ServiceFAQ.tsx
+++ b/app/components/ServiceFAQ/ServiceFAQ.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import styles from './ServiceFAQ.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceFAQProps {
+  service: Service
+}
+
+export default function ServiceFAQ({ service }: ServiceFAQProps) {
+  const [activeItems, setActiveItems] = useState<number[]>([])
+
+  // Generate FAQ Schema for SEO
+  useEffect(() => {
+    if (!service?.faq?.items?.length) return
+
+    const faqSchema = {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": service.faq.items.map((item) => ({
+        "@type": "Question",
+        "name": item.question,
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": item.answer
+        }
+      }))
+    }
+
+    // Remove existing FAQ schema if any
+    const existingSchema = document.querySelector('script[data-schema="service-faq"]')
+    if (existingSchema) {
+      existingSchema.remove()
+    }
+
+    // Add new FAQ schema
+    const scriptTag = document.createElement('script')
+    scriptTag.type = 'application/ld+json'
+    scriptTag.setAttribute('data-schema', 'service-faq')
+    scriptTag.textContent = JSON.stringify(faqSchema)
+    document.head.appendChild(scriptTag)
+
+    // Cleanup function to remove schema when component unmounts
+    return () => {
+      const schemaToRemove = document.querySelector('script[data-schema="service-faq"]')
+      if (schemaToRemove) {
+        schemaToRemove.remove()
+      }
+    }
+  }, [service?.faq?.items])
+
+  const toggleFAQ = (index: number) => {
+    setActiveItems(prev => 
+      prev.includes(index) 
+        ? prev.filter(i => i !== index)
+        : [...prev, index]
+    )
+  }
+
+  if (!service?.faq?.items?.length) {
+    return null
+  }
+
+  return (
+    <section className={styles.faq}>
+      <div className={styles.faqContainer}>
+        <div className={styles.faqTitle}>
+          <h2>{service.faq.title}</h2>
+          <p>{service.faq.subtitle}</p>
+        </div>
+        <div className={styles.faqAccordion}>
+          {service.faq.items.map((item, index) => (
+            <div 
+              key={index} 
+              className={`${styles.faqItem} ${activeItems.includes(index) ? styles.active : ''}`}
+            >
+              <h3 
+                className={styles.faqQuestion}
+                onClick={() => toggleFAQ(index)}
+              >
+                <span className={styles.toggleIcon}>
+                  {activeItems.includes(index) ? '-' : '+'}
+                </span>
+                {item.question}
+              </h3>
+              <div className={styles.faqAnswer}>
+                <div className={styles.answerContent}>
+                  {item.answer}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/components/ServiceFeaturesOverview/ServiceFeaturesOverview.module.css
+++ b/app/components/ServiceFeaturesOverview/ServiceFeaturesOverview.module.css
@@ -1,0 +1,73 @@
+/* Features Overview Styles */
+
+.howItWorks {
+  display: flex;
+  flex-direction: column;
+  margin: 50px 3% 70px 3%;
+  margin-bottom: 70px;
+}
+
+.hitContainer {
+  /* Container for additional styling if needed */
+}
+
+.hitSteps {
+  margin-top: 30px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
+  gap: 3%;
+  text-align: center;
+}
+
+.hitStep {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.hitStep p {
+  font-size: 1.125rem; /* 18px */
+}
+
+.hitStep h4 {
+  margin: 5px 0 10px 0;
+  transition: 0.3s;
+  font-size: 1.25rem; /* 20px */
+}
+
+.hitStep:hover h4 {
+  color: #10b981; 
+  transition: 0.3s;
+}
+
+.hitStep img {
+  width: 85px;
+  height: 85px;
+  margin-bottom: 10px;
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .hitSteps {
+    flex-direction: column;
+  }
+
+  .howItWorks {
+    margin: 50px 3% 30px 3%;
+  }
+
+  .hitStep img {
+    width: 65px;
+    height: 65px;
+  }
+
+  .hitStep {
+    margin-bottom: 15px;
+  }
+
+  .hitStep p {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+}

--- a/app/components/ServiceFeaturesOverview/ServiceFeaturesOverview.tsx
+++ b/app/components/ServiceFeaturesOverview/ServiceFeaturesOverview.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image'
+import styles from './ServiceFeaturesOverview.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceFeaturesOverviewProps {
+  service: Service
+}
+
+export default function ServiceFeaturesOverview({ service }: ServiceFeaturesOverviewProps) {
+  if (!service?.featuresOverview?.items?.length) {
+    return null
+  }
+
+  return (
+    <section className={styles.howItWorks}>
+      <div className={styles.hitContainer}></div>
+      <div className={styles.hitSteps}>
+        {service.featuresOverview.items.map((item, index) => (
+          <div key={index} className={styles.hitStep}>
+            {item.image && (
+              <Image 
+                src={item.image} 
+                alt={item.imageAlt || item.title}
+                width={85}
+                height={85}
+              />
+            )}
+            <h4>{item.title}</h4>
+            <p>{item.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/app/components/ServiceHero/ServiceHero.module.css
+++ b/app/components/ServiceHero/ServiceHero.module.css
@@ -1,0 +1,134 @@
+/* Service Hero Styles based on the provided CSS */
+
+.heroContainer {
+  margin-top: 50px;
+}
+
+.hero {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(to right, #e4e6e8, white);
+  border-radius: 30px 0 0 30px;
+}
+
+.left {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-radius: 0 25% 0 0;
+  width: 50%;
+}
+
+.left p {
+  margin: 10px 0;
+  font-size: 1.125rem; /* 18px */
+}
+
+.leftText {
+  margin: 10%;
+}
+
+.left h1 {
+  margin: 10px 0;
+  font-size: 3.125rem; /* 50px */
+}
+
+.heroCTAButton {
+  height: 47px;
+  line-height: 47px;
+  border: none;
+  cursor: pointer;
+  transition: 0.3s;
+  background-color: #10b981 !important;
+  color: white;
+  padding: 0 25px;
+  border-radius: 30px;
+  font-size: 1.125rem; /* 18px */
+}
+
+.heroCTAButton:hover {
+  transform: translateY(-3px);
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  transition: 0.3s;
+}
+
+.heroCTAButton:active {
+  transform: translateY(1px);
+  box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.8);
+  transition: 0.1s;
+}
+
+.right {
+  border-radius: 25% 0 0 0;
+  height: 500px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: 50%;
+}
+
+.rightB {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+.right img {
+  mix-blend-mode: multiply;
+  filter: brightness(1.03);
+  max-height: 500px;
+}
+
+.buttonsHolder {
+  margin-top: 12% !important;
+  display: flex;
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .hero {
+    flex-direction: column-reverse;
+    background: #e4e6e8;
+    border-radius: 0 0 30px 30px;
+  }
+
+  .right {
+    width: 100%;
+    border-radius: 0 0 0 25%;
+    height: 300px;
+  }
+
+  .right img {
+    max-height: 300px;
+    margin-top: 15%;
+  }
+
+  .left {
+    width: 100%;
+    border-radius: 0 0 10% 10%;
+  }
+
+  .left h1 {
+    font-size: 1.875rem; /* 30px */
+  }
+
+  .left p {
+    font-size: 0.875rem; /* 14px */
+  }
+
+  .leftText {
+    margin: 15% 5% 8% 5%; /* Reduced margins */
+  }
+
+  .heroContainer {
+    margin-top: 5px;
+  }
+
+  .heroCTAButton {
+    font-size: 16px;
+  }
+}

--- a/app/components/ServiceHero/ServiceHero.tsx
+++ b/app/components/ServiceHero/ServiceHero.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import styles from './ServiceHero.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceHeroProps {
+  service: Service
+}
+
+export default function ServiceHero({ service }: ServiceHeroProps) {
+  return (
+    <section className={styles.heroContainer}>
+      <div className={styles.hero}>
+        <div className={styles.left}>
+          <div className={styles.leftText}>
+            <p>{service?.hero?.subheading || 'Formulating Beauty Excellence'}</p>
+            <h1>{service?.hero?.heading || service?.name || 'Loading...'}</h1>
+            <p>{service?.hero?.description || 'Loading...'}</p>
+            
+            <div className={styles.buttonsHolder}>
+              <Link href={service?.hero?.ctaUrl || '/contact-us'} target={service?.hero?.ctaUrl ? '_blank' : '_self'}>
+                <button className={styles.heroCTAButton}>
+                  {service?.hero?.ctaText || 'Book a Call'}
+                </button>
+              </Link>
+            </div>
+          </div>
+        </div>
+        <div className={styles.right}>
+          <div className={styles.rightB}>
+            {service?.hero?.image && (
+              <Image 
+                src={service.hero.image} 
+                alt={service?.hero?.imageAlt || `${service?.name} service image`}
+                width={500}
+                height={500}
+                priority
+                style={{
+                  width: '100%',
+                  height: 'auto',
+                  maxWidth: '500px',
+                  objectFit: 'contain'
+                }}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/components/ServiceMiddleCTA/ServiceMiddleCTA.module.css
+++ b/app/components/ServiceMiddleCTA/ServiceMiddleCTA.module.css
@@ -1,0 +1,114 @@
+/* Service Middle CTA Styles */
+
+.middleCTA {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  background-color: #e4e6e8;
+  padding: 2% 0;
+  overflow: hidden;
+  z-index: 0;
+  margin-bottom: 50px;
+}
+
+.mctaText {
+  display: flex;
+  flex-direction: column;
+}
+
+.mctaText p {
+  font-size: 1.125rem; /* 18px */
+  margin-bottom: 5px;
+}
+
+.mctaText h2 {
+  font-size: 2.5rem; /* 40px */
+  margin-bottom: 15px;
+}
+
+.mctaText button svg {
+  width: 70px;
+  height: 35px;
+  margin-left: 10px;
+}
+
+.mctaText button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 2px solid #10b981 !important;
+  background-color: transparent !important;
+  color: #10b981 !important;
+  padding: 10px 20px;
+  cursor: pointer;
+  border-radius: 30px;
+  width: 70%;
+  transition: 0.3s;
+  font-size: 1.125rem; /* 18px */
+}
+
+.mctaText button:hover {
+  border: 2px solid transparent !important;
+  background-color: #10b981 !important;
+  color: white !important;
+  padding: 10px 20px;
+  width: 75%;
+  transition: 0.3s;
+}
+
+.mctaText button:hover svg line {
+  stroke: white;
+}
+
+.mctaText button:hover svg polygon {
+  fill: white;
+}
+
+.blobContainer {
+  position: absolute;
+  width: 350px;
+  height: 350px;
+  z-index: 0;
+  left: 15%;
+  transition: transform 0.3s ease;
+  display: none;
+}
+
+.middleCTA:hover .blobContainer {
+  transform: translate(-10px, -10px);
+}
+
+.middleCTA img {
+  position: relative;
+  z-index: 1;
+  mix-blend-mode: multiply;
+  filter: brightness(1.03);
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .middleCTA {
+    flex-direction: column;
+  }
+
+  .mctaText {
+    margin: 10% 5% 5% 5%;
+  }
+
+  .mctaText p {
+    font-size: 0.875rem; /* 14px on mobile */
+    margin-bottom: 20px;
+    line-height: 1.1;
+  }
+
+  .mctaText h2 {
+    line-height: 1.25;
+  }
+
+  .mctaText button {
+    width: 90%;
+    margin-top: 5%;
+    font-size: 15px;
+  }
+}

--- a/app/components/ServiceMiddleCTA/ServiceMiddleCTA.tsx
+++ b/app/components/ServiceMiddleCTA/ServiceMiddleCTA.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import styles from './ServiceMiddleCTA.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceMiddleCTAProps {
+  service: Service
+}
+
+export default function ServiceMiddleCTA({ service }: ServiceMiddleCTAProps) {
+  if (!service?.middleCTA) {
+    return null
+  }
+
+  return (
+    <section className={styles.middleCTA}>
+      <div>
+        <div className={styles.blobContainer}>
+          <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+            <path 
+              fill="#1D413C30" 
+              d="M63.1,-38.8C70,-24.4,55.8,-0.2,41.8,16.3C27.7,32.7,13.9,41.5,-3.8,43.7C-21.5,45.9,-43,41.6,-54,26.9C-64.9,12.3,-65.2,-12.8,-54.4,-29.3C-43.6,-45.9,-21.8,-54,3.1,-55.8C28.1,-57.6,56.2,-53.1,63.1,-38.8Z" 
+              transform="translate(100 100)" 
+            />
+          </svg>
+        </div>
+        {service.middleCTA.image && (
+          <Image 
+            src={service.middleCTA.image} 
+            alt={service.middleCTA.imageAlt || 'Service CTA image'}
+            width={300}
+            height={300}
+          />
+        )}
+      </div>
+      <div className={styles.mctaText}>
+        <p>{service.middleCTA.subheading}</p>
+        <h2>{service.middleCTA.heading}</h2>
+        <Link href={service.middleCTA.ctaUrl || '/contact-us'} target="_blank">
+          <button>
+            <span>{service.middleCTA.ctaText}</span>
+            <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1422 800">
+              <g strokeWidth="19" stroke="#10b981" fill="none" strokeLinecap="round" strokeLinejoin="round" transform="rotate(315, 711, 400)">
+                <line x1="386" y1="75" x2="1036" y2="725" markerEnd="url(#SvgjsMarker1411)"></line>
+              </g>
+              <defs>
+                <marker markerWidth="15" markerHeight="15" refX="7.5" refY="7.5" viewBox="0 0 15 15" orient="auto" id="SvgjsMarker1411">
+                  <polygon points="0,15 7.5,7.5 0,0 15,7.5" fill="#10b981"></polygon>
+                </marker>
+              </defs>
+            </svg>
+          </button>
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/app/components/ServiceProcess/ServiceProcess.module.css
+++ b/app/components/ServiceProcess/ServiceProcess.module.css
@@ -1,0 +1,102 @@
+/* Service Process (How It Works) Styles */
+
+.howItWorks {
+  display: flex;
+  flex-direction: column;
+  margin: 50px 3% 70px 3%;
+  margin-bottom: 70px;
+}
+
+.hitContainer {
+  /* Container for additional styling if needed */
+}
+
+.hitTitles {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin: 0 15%;
+}
+
+.hitTitles h2 {
+  font-size: 2.5rem; /* 40px */
+  margin-bottom: 15px;
+}
+
+.hitTitles p {
+  font-size: 1.125rem; /* 18px */
+}
+
+.hitSteps {
+  margin-top: 30px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
+  gap: 3%;
+  text-align: center;
+}
+
+.hitStep {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.hitStep p {
+  font-size: 1.125rem; /* 18px */
+}
+
+.hitStep h4 {
+  margin: 5px 0 10px 0;
+  transition: 0.3s;
+  font-size: 1.25rem; /* 20px */
+}
+
+.hitStep:hover h4 {
+  color: #10b981; 
+  transition: 0.3s;
+}
+
+.hitStep img {
+  width: 85px;
+  height: 85px;
+  margin-bottom: 10px;
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .hitSteps {
+    flex-direction: column;
+  }
+
+  .howItWorks {
+    margin: 50px 3% 30px 3%;
+  }
+
+  .hitStep img {
+    width: 65px;
+    height: 65px;
+  }
+
+  .hitStep {
+    margin-bottom: 15px;
+  }
+
+  .hitTitles {
+    margin: 0 5%;
+  }
+
+  .hitTitles h2 {
+    font-size: 1.5625rem; /* 25px */
+  }
+
+  .hitTitles p {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+
+  .hitStep p {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+}

--- a/app/components/ServiceProcess/ServiceProcess.tsx
+++ b/app/components/ServiceProcess/ServiceProcess.tsx
@@ -1,0 +1,39 @@
+import Image from 'next/image'
+import styles from './ServiceProcess.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceProcessProps {
+  service: Service
+}
+
+export default function ServiceProcess({ service }: ServiceProcessProps) {
+  if (!service?.process?.steps?.length) {
+    return null
+  }
+
+  return (
+    <section className={styles.howItWorks}>
+      <div className={styles.hitContainer}></div>
+      <div className={styles.hitTitles}>
+        <h2>{service.process.title}</h2>
+        <p>{service.process.description}</p>
+      </div>
+      <div className={styles.hitSteps}>
+        {service.process.steps.map((step, index) => (
+          <div key={index} className={styles.hitStep}>
+            {step.image && (
+              <Image 
+                src={step.image} 
+                alt={step.imageAlt || step.title}
+                width={85}
+                height={85}
+              />
+            )}
+            <h4>{step.title}</h4>
+            <p>{step.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/app/components/ServiceProductRange/ServiceProductRange.module.css
+++ b/app/components/ServiceProductRange/ServiceProductRange.module.css
@@ -1,0 +1,107 @@
+/* Service Product Range Styles */
+
+.featuresParent {
+  margin-top: 50px;
+}
+
+.hitTitles {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin: 0 15%;
+}
+
+.hitTitles h2 {
+  font-size: 2.5rem; /* 40px */
+  margin-bottom: 15px;
+}
+
+.hitTitles p {
+  font-size: 1.125rem; /* 18px */
+}
+
+.productFeatures {
+  margin-top: 70px;
+  margin-bottom: 70px;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.productFeaturesMobile {
+  display: none;
+}
+
+.featureHolder {
+  display: flex;
+  flex-direction: row;
+  padding: 15px 20px;
+  gap: 10px;
+  align-items: center;
+  transition: 0.3s;
+  margin-bottom: 1px;
+  border-bottom: 3px solid transparent;
+  border-radius: 5px;
+  gap: 30px;
+}
+
+.featureHolder:hover {
+  transition: 0.3s;
+}
+
+.featureHolder img {
+  width: 75px;
+  height: 75px;
+}
+
+.featureHolder h3 {
+  margin-bottom: 5px;
+}
+
+.featureHolder p {
+  margin: 0;
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .productFeatures {
+    display: none;
+  }
+
+  .productFeaturesMobile {
+    display: flex;
+    flex-direction: column;
+    margin-top: 40px;
+    margin-bottom: 30px;
+  }
+
+  .featureHolderMobile {
+    display: flex;
+    justify-content: space-around;
+  }
+
+  .featureHolder img {
+    width: 50px;
+    height: 50px;
+  }
+
+  .featureHolder {
+    flex-direction: column;
+    gap: 5px;
+    text-align: center;
+    padding-bottom: 0;
+  }
+
+  .hitTitles {
+    margin: 0 5%;
+  }
+
+  .hitTitles h2 {
+    font-size: 1.5625rem; /* 25px */
+  }
+
+  .hitTitles p {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+}

--- a/app/components/ServiceProductRange/ServiceProductRange.tsx
+++ b/app/components/ServiceProductRange/ServiceProductRange.tsx
@@ -1,0 +1,114 @@
+import Image from 'next/image'
+import styles from './ServiceProductRange.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceProductRangeProps {
+  service: Service
+}
+
+export default function ServiceProductRange({ service }: ServiceProductRangeProps) {
+  if (!service?.productRange?.items?.length) {
+    return null
+  }
+
+  const items = service.productRange.items
+  const leftItems = items.slice(0, Math.ceil(items.length / 2))
+  const rightItems = items.slice(Math.ceil(items.length / 2))
+
+  return (
+    <div className={styles.featuresParent}>
+      <div className={styles.hitTitles}>
+        <h2>{service.productRange.heading}</h2>
+        <p>{service.productRange.description}</p>
+      </div>
+      
+      {/* Desktop Layout */}
+      <section className={styles.productFeatures}>
+        <div className={styles.featuresContainer}>
+          {leftItems.map((item, index) => (
+            <div key={index}>
+              <div className={styles.featureHolder}>
+                {item.image && (
+                  <Image 
+                    src={item.image} 
+                    alt={item.imageAlt || item.title}
+                    width={75}
+                    height={75}
+                  />
+                )}
+                <div>
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        
+        <div className={styles.featuresContainer}>
+          {rightItems.map((item, index) => (
+            <div key={index}>
+              <div className={styles.featureHolder}>
+                {item.image && (
+                  <Image 
+                    src={item.image} 
+                    alt={item.imageAlt || item.title}
+                    width={75}
+                    height={75}
+                  />
+                )}
+                <div>
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Mobile Layout */}
+      <section className={styles.productFeaturesMobile}>
+        <div className={styles.featureHolderMobile}>
+          <div className={styles.featuresContainer}>
+            {leftItems.map((item, index) => (
+              <div key={index} className={styles.featureHolder}>
+                {item.image && (
+                  <Image 
+                    src={item.image} 
+                    alt={item.imageAlt || item.title}
+                    width={50}
+                    height={50}
+                  />
+                )}
+                <div>
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className={styles.featuresContainer}>
+            {rightItems.map((item, index) => (
+              <div key={index} className={styles.featureHolder}>
+                {item.image && (
+                  <Image 
+                    src={item.image} 
+                    alt={item.imageAlt || item.title}
+                    width={50}
+                    height={50}
+                  />
+                )}
+                <div>
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/components/ServiceSpecialties/ServiceSpecialties.module.css
+++ b/app/components/ServiceSpecialties/ServiceSpecialties.module.css
@@ -1,0 +1,158 @@
+/* Service Specialties Slider Styles */
+
+.imageSlider {
+  position: relative;
+  width: 100%;
+  margin: 70px 0;
+}
+
+.hitContainer {
+  /* Container for additional styling if needed */
+}
+
+.hitTitles {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin: 0 15%;
+}
+
+.hitTitles h2 {
+  font-size: 2.5rem; /* 40px */
+  margin-bottom: 15px;
+}
+
+.hitTitles p {
+  font-size: 1.125rem; /* 18px */
+}
+
+.sliderContainer {
+  overflow: hidden;
+  margin: 30px;
+  position: relative;
+  touch-action: pan-x; /* Allow horizontal panning for swipe */
+  user-select: none; /* Prevent text selection during swipe */
+}
+
+.formulations {
+  display: flex;
+  transition: transform 0.5s ease;
+  gap: 30px;
+  box-sizing: border-box;
+}
+
+.formulation {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 40px;
+  transition: 0.3s;
+  background: #e4e6e8;
+  border-radius: 30px 30px 0 0;
+  border-bottom: 3px solid #10b981;
+  box-sizing: border-box;
+  flex: 0 0 calc(33.333% - 20px); /* 3 items per row with gap */
+  width: calc(33.333% - 20px);
+}
+
+.formulation:hover {
+  background: #f0f2f4;
+  transition: 0.3s;
+}
+
+.formulations img {
+  width: 75px;
+  margin-bottom: 15px;
+  height: auto;
+}
+
+.prevF, .nextF {
+  position: absolute;
+  top: calc(50% + 60px); /* Adjust to be in middle of cards (accounting for titles) */
+  transform: translateY(-50%);
+  font-size: 30px;
+  cursor: pointer;
+  background: #ffffffeb !important;
+  border: none !important;
+  color: #10b981 !important;
+  transition: 0.3s;
+  z-index: 2;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.prevF { 
+  left: 10px;
+}
+
+.nextF { 
+  right: 10px;
+}
+
+.prevF:hover, .nextF:hover {
+  background: #10b981 !important;
+  color: #fff !important;
+  transition: 0.3s;
+  transform: translateY(-50%) scale(1.1);
+}
+
+/* Desktop and Tablet styles (769px and up) */
+@media screen and (min-width: 769px) {
+  .sliderContainer {
+    margin: 30px;
+  }
+
+  .formulation {
+    padding: 40px;
+  }
+}
+
+/* Mobile styles */
+@media screen and (max-width: 768px) {
+  .sliderContainer {
+    margin: 20px;
+  }
+
+  .formulations {
+    gap: 20px;
+  }
+
+  .formulation {
+    padding: 30px 20px;
+    flex: 0 0 calc(100% - 20px); /* 1 item per row on mobile */
+    width: calc(100% - 20px);
+  }
+
+  .hitTitles {
+    margin: 0 5%;
+  }
+
+  .hitTitles h2 {
+    font-size: 1.5625rem; /* 25px */
+  }
+
+  .hitTitles p {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+
+  .prevF, .nextF {
+    width: 42px; /* 15% smaller than 50px = 42.5px */
+    height: 42px;
+    font-size: 25px; /* 15% smaller than 30px = 25.5px */
+    top: calc(50% + 40px); /* Adjust for mobile card height */
+  }
+
+  .prevF {
+    left: 5px;
+  }
+
+  .nextF {
+    right: 5px;
+  }
+}

--- a/app/components/ServiceSpecialties/ServiceSpecialties.tsx
+++ b/app/components/ServiceSpecialties/ServiceSpecialties.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Image from 'next/image'
+import styles from './ServiceSpecialties.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceSpecialtiesProps {
+  service: Service
+}
+
+export default function ServiceSpecialties({ service }: ServiceSpecialtiesProps) {
+  const [currentSlide, setCurrentSlide] = useState(0)
+  const [visibleItems, setVisibleItems] = useState(3)
+  const [touchStart, setTouchStart] = useState<number | null>(null)
+  const [touchEnd, setTouchEnd] = useState<number | null>(null)
+
+  // Update visible items based on screen size
+  const updateVisibleItems = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      const screenWidth = window.innerWidth
+      if (screenWidth <= 768) {
+        setVisibleItems(1)
+      } else {
+        setVisibleItems(3) // Always show 3 columns on desktop and tablet
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    updateVisibleItems()
+    window.addEventListener('resize', updateVisibleItems)
+    return () => window.removeEventListener('resize', updateVisibleItems)
+  }, [updateVisibleItems])
+
+  // Reset slide position if it exceeds new bounds
+  useEffect(() => {
+    const items = service?.specialties?.items || []
+    const totalSlides = Math.max(0, items.length - visibleItems)
+    if (currentSlide > totalSlides) {
+      setCurrentSlide(Math.max(0, totalSlides))
+    }
+  }, [currentSlide, visibleItems, service?.specialties?.items])
+
+  if (!service?.specialties?.items?.length) {
+    return null
+  }
+
+  const items = service.specialties.items
+  const totalSlides = Math.max(0, items.length - visibleItems)
+
+  const moveService = (step: number) => {
+    let newSlide = currentSlide + step
+    
+    if (newSlide < 0) {
+      newSlide = 0
+    } else if (newSlide > totalSlides) {
+      newSlide = totalSlides
+    }
+
+    setCurrentSlide(newSlide)
+  }
+
+  // Minimum swipe distance (in px)
+  const minSwipeDistance = 50
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    setTouchEnd(null) // otherwise the swipe is fired even with usual touch events
+    setTouchStart(e.targetTouches[0].clientX)
+  }
+
+  const onTouchMove = (e: React.TouchEvent) => {
+    setTouchEnd(e.targetTouches[0].clientX)
+  }
+
+  const onTouchEnd = () => {
+    if (!touchStart || !touchEnd) return
+    
+    const distance = touchStart - touchEnd
+    const isLeftSwipe = distance > minSwipeDistance
+    const isRightSwipe = distance < -minSwipeDistance
+
+    if (isLeftSwipe && currentSlide < totalSlides) {
+      moveService(1) // swipe left = next slide
+    }
+    if (isRightSwipe && currentSlide > 0) {
+      moveService(-1) // swipe right = previous slide
+    }
+  }
+
+  // Calculate translate value
+  // Each slide moves by the width of one item plus gap
+  const itemWidthWithGap = visibleItems === 1 ? 100 : (100 / 3) // 33.333% for desktop, 100% for mobile
+  const translateX = currentSlide * itemWidthWithGap
+
+  return (
+    <section className={styles.imageSlider}>
+      <div className={styles.hitContainer}></div>
+      <div className={styles.hitTitles}>
+        <h2>{service.specialties.heading}</h2>
+        <p>{service.specialties.description}</p>
+      </div>
+      
+      <div 
+        className={styles.sliderContainer}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+      >
+        <div 
+          className={styles.formulations}
+          style={{ 
+            transform: `translateX(-${translateX}%)`,
+          }}
+        >
+          {items.map((item, index) => (
+            <div 
+              key={index} 
+              className={styles.formulation}
+            >
+              {item.image && (
+                <Image 
+                  src={item.image} 
+                  alt={item.imageAlt || item.title}
+                  width={75}
+                  height={75}
+                />
+              )}
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      
+      {currentSlide > 0 && (
+        <button 
+          className={styles.prevF} 
+          onClick={() => moveService(-1)}
+          aria-label="Previous specialty"
+        >
+          ❮
+        </button>
+      )}
+      
+      {currentSlide < totalSlides && (
+        <button 
+          className={styles.nextF} 
+          onClick={() => moveService(1)}
+          aria-label="Next specialty"
+        >
+          ❯
+        </button>
+      )}
+    </section>
+  )
+}

--- a/app/components/ServiceValue/ServiceValue.module.css
+++ b/app/components/ServiceValue/ServiceValue.module.css
@@ -1,0 +1,105 @@
+/* Service Value Styles */
+
+.valueContainer {
+  margin-top: 50px;
+  align-items: center;
+}
+
+.value {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+}
+
+.valueLeft, .valueRight {
+  width: 50%;
+}
+
+.valueLeftText {
+  margin: 10%;
+}
+
+.value .right img {
+  mix-blend-mode: multiply;
+  filter: brightness(1.03);
+  max-height: 400px;
+}
+
+.value h2 {
+  position: relative;
+  display: inline-block;
+  font-size: 2.5rem; /* 40px */
+  margin-bottom: 15px;
+}
+
+.value h2::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: #333;
+  margin-top: 15px;
+}
+
+.valueLeftText p {
+  font-size: 1.125rem; /* 18px */
+}
+
+
+
+.right {
+  border-radius: 25% 0 0 0;
+  height: 500px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: 50%;
+}
+
+.rightB {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+/* Mobile styles */
+@media screen and (max-width: 600px) {
+  .value {
+    flex-direction: column;
+    margin-bottom: 40px;
+    gap: 0px;
+  }
+
+  .valueLeft, .valueRight {
+    width: 95%;
+  }
+
+  .valueLeftText {
+    margin: 20% 10% 10% 10%;
+  }
+
+  .value .right img {
+    max-height: 300px;
+  }
+
+  .valueContainer {
+    margin-top: 0;
+  }
+
+  .value h2 {
+    font-size: 1.5625rem; /* 25px */
+  }
+
+  .valueLeftText p {
+    font-size: 0.875rem; /* 14px on mobile */
+  }
+
+  .valueLeftText {
+    margin: 15% 5% 8% 5%; /* Reduced margins */
+  }
+}

--- a/app/components/ServiceValue/ServiceValue.tsx
+++ b/app/components/ServiceValue/ServiceValue.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image'
+import styles from './ServiceValue.module.css'
+import { Service } from '@/types/Service'
+
+interface ServiceValueProps {
+  service: Service
+}
+
+export default function ServiceValue({ service }: ServiceValueProps) {
+  if (!service?.value) {
+    return null
+  }
+
+  return (
+    <section className={styles.valueContainer}>
+      <div className={styles.value}>
+        <div className={styles.right}>
+          <div className={styles.rightB}>
+            {service.value.image && (
+              <Image 
+                src={service.value.image} 
+                alt={service.value.imageAlt || 'Service value image'}
+                width={400}
+                height={400}
+                style={{
+                  width: '100%',
+                  height: 'auto',
+                  maxWidth: '400px',
+                  objectFit: 'contain'
+                }}
+              />
+            )}
+          </div>
+        </div>
+        <div className={styles.valueLeft}>
+          <div className={styles.valueLeftText}>
+            <h2>{service.value.heading}</h2>
+            <p>{service.value.description}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -36,6 +36,13 @@ type SitemapProduct = {
   _updatedAt: string
 }
 
+type SitemapService = {
+  _id: string
+  name: string
+  slug: string
+  _updatedAt: string
+}
+
 export async function GET() {
   try {
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.elixderm.com'
@@ -57,6 +64,12 @@ export async function GET() {
       },
       { 
         url: '/products', 
+        changeFreq: 'weekly' as const, 
+        priority: 0.9,
+        lastModified: new Date().toISOString()
+      },
+      { 
+        url: '/services', 
         changeFreq: 'weekly' as const, 
         priority: 0.9,
         lastModified: new Date().toISOString()
@@ -86,7 +99,7 @@ export async function GET() {
     })
 
     // Fetch dynamic pages from Sanity
-    const [pages, projects, products] = await Promise.all([
+    const [pages, projects, products, services] = await Promise.all([
       // Pages
       client.fetch(`*[_type == "page" && defined(slug.current)] {
         _id,
@@ -103,6 +116,13 @@ export async function GET() {
       }`),
       // Products
       client.fetch(`*[_type == "product" && defined(slug.current)] {
+        _id,
+        name,
+        "slug": slug.current,
+        _updatedAt
+      }`),
+      // Services
+      client.fetch(`*[_type == "service" && defined(slug.current)] {
         _id,
         name,
         "slug": slug.current,
@@ -135,6 +155,16 @@ export async function GET() {
       sitemap.push({
         url: `${baseUrl}/products/${product.slug}`,
         lastModified: new Date(product._updatedAt).toISOString(),
+        changeFreq: 'weekly',
+        priority: 0.8
+      })
+    })
+
+    // Add services
+    services.forEach((service: SitemapService) => {
+      sitemap.push({
+        url: `${baseUrl}/services/${service.slug}`,
+        lastModified: new Date(service._updatedAt).toISOString(),
         changeFreq: 'weekly',
         priority: 0.8
       })

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -46,6 +46,7 @@ const config = defineConfig({
             S.documentTypeListItem('page'),
             S.documentTypeListItem('project'),
             S.documentTypeListItem('product'),
+            S.documentTypeListItem('service'),
           ])
     })
   ],

--- a/sanity/components/SiteURLs.tsx
+++ b/sanity/components/SiteURLs.tsx
@@ -69,6 +69,7 @@ export default function SiteURLs() {
         { title: 'Home', url: '/', type: 'Static Page' },
         { title: 'About', url: '/about', type: 'Static Page' },
         { title: 'Products', url: '/products', type: 'Static Page' },
+        { title: 'Services', url: '/services', type: 'Static Page' },
         { title: 'Contact Us', url: '/contact-us', type: 'Static Page' },
         { title: 'Sitemap', url: '/sitemap', type: 'Static Page' },
       ]
@@ -87,7 +88,7 @@ export default function SiteURLs() {
       })
 
       // Fetch dynamic pages from Sanity with proper slug handling
-      const [pages, projects, products] = await Promise.all([
+      const [pages, projects, products, services] = await Promise.all([
         // Pages
         client.fetch(`*[_type == "page" && defined(slug.current)] {
           _id,
@@ -109,6 +110,18 @@ export default function SiteURLs() {
         }`),
         // Products  
         client.fetch(`*[_type == "product" && defined(slug.current)] {
+          _id,
+          name,
+          "slug": slug.current,
+          _updatedAt,
+          seo {
+            metaTitle,
+            metaDescription,
+            noIndex
+          }
+        }`),
+        // Services
+        client.fetch(`*[_type == "service" && defined(slug.current)] {
           _id,
           name,
           "slug": slug.current,
@@ -167,6 +180,24 @@ export default function SiteURLs() {
           metaDescription: product.seo?.metaDescription,
           canonical: `${baseUrl}/products/${product.slug}`,
           noIndex: product.seo?.noIndex,
+          canEdit: true,
+          canDelete: true
+        })
+      })
+
+      // Add services
+      services.forEach((service: any) => {
+        allUrls.push({
+          id: service._id,
+          title: service.name,
+          url: `${baseUrl}/services/${service.slug}`,
+          type: 'Service',
+          status: 'Published',
+          lastModified: new Date(service._updatedAt).toLocaleDateString(),
+          metaTitle: service.seo?.metaTitle,
+          metaDescription: service.seo?.metaDescription,
+          canonical: `${baseUrl}/services/${service.slug}`,
+          noIndex: service.seo?.noIndex,
           canEdit: true,
           canDelete: true
         })

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -2,6 +2,7 @@ import { createClient, groq } from "next-sanity";
 import { Project } from "@/types/project";
 import { Page } from "@/types/Page";
 import { Product } from "@/types/Product";
+import { Service } from "@/types/Service";
 import clientConfig from "./config/client-config";
 export async function getProjects(): Promise<Project[]> {
   return createClient(clientConfig).fetch(groq`*[_type == "project"]{
@@ -169,6 +170,130 @@ export async function getProduct(slug: string): Promise<Product> {
       bottomCTA {
         text,
         buttonText
+      }
+    }`,
+    { slug }
+  );
+}
+
+export async function getServices(): Promise<Service[]> {
+  return createClient(clientConfig).fetch(groq`*[_type == "service"]{
+    _id,
+    _createdAt,
+    name,
+    "slug": slug.current,
+    menuName,
+    showInMenu,
+    category,
+    hero {
+      heading,
+      description
+    }
+  }`);
+}
+
+export async function getMenuServices(): Promise<Service[]> {
+  return createClient(clientConfig).fetch(groq`*[_type == "service" && showInMenu == true] | order(category asc, name asc){
+    _id,
+    name,
+    "slug": slug.current,
+    menuName,
+    category
+  }`);
+}
+
+export async function getService(slug: string): Promise<Service> {
+  return createClient(clientConfig).fetch(
+    groq`*[_type == "service" && slug.current == $slug][0]{
+      _id,
+      _createdAt,
+      name,
+      "slug": slug.current,
+      menuName,
+      showInMenu,
+      category,
+      seo {
+        metaTitle,
+        metaDescription,
+        noIndex
+      },
+      hero {
+        subheading,
+        heading,
+        description,
+        ctaText,
+        ctaUrl,
+        "image": image.asset->url,
+        imageAlt
+      },
+      featuresOverview {
+        items[] {
+          "image": image.asset->url,
+          imageAlt,
+          title,
+          description
+        }
+      },
+      value {
+        heading,
+        description,
+        "image": image.asset->url,
+        imageAlt
+      },
+      specialties {
+        heading,
+        description,
+        items[] {
+          "image": image.asset->url,
+          imageAlt,
+          title,
+          description
+        }
+      },
+      process {
+        title,
+        description,
+        steps[] {
+          "image": image.asset->url,
+          imageAlt,
+          title,
+          description
+        }
+      },
+      topCTA {
+        text,
+        url
+      },
+      productRange {
+        heading,
+        description,
+        items[] {
+          "image": image.asset->url,
+          imageAlt,
+          title,
+          description
+        }
+      },
+      middleCTA {
+        subheading,
+        heading,
+        ctaText,
+        ctaUrl,
+        "image": image.asset->url,
+        imageAlt
+      },
+      faq {
+        title,
+        subtitle,
+        items[] {
+          question,
+          answer
+        }
+      },
+      bottomCTA {
+        text,
+        buttonText,
+        url
       }
     }`,
     { slug }

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -4,7 +4,8 @@ import page from "./page-schema";
 import contact from "./contact-schema";
 import homeContact from "./home-contact-schema";
 import product from "./product-schema";
+import service from "./service-schema";
 
-const schemas = [project, page, contact, homeContact, product];
+const schemas = [project, page, contact, homeContact, product, service];
 
 export default schemas;

--- a/sanity/schemas/service-schema.ts
+++ b/sanity/schemas/service-schema.ts
@@ -1,0 +1,572 @@
+const service = {
+  name: 'service',
+  title: 'Services',
+  type: 'document',
+  icon: () => '🔬',
+  fields: [
+    {
+      name: 'name',
+      title: 'Service Name',
+      type: 'string',
+      validation: (Rule: any) => Rule.required()
+    },
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'name'
+      },
+      validation: (Rule: any) => Rule.required()
+    },
+    // Menu Settings
+    {
+      name: 'menuName',
+      title: 'Menu Display Name',
+      type: 'string',
+      description: 'Custom name to display in navigation menu (leave empty to use Service Name)'
+    },
+    {
+      name: 'showInMenu',
+      title: 'Show in Navigation Menu',
+      type: 'boolean',
+      description: 'Toggle to control if this service appears in the main navigation menu',
+      initialValue: true
+    },
+    {
+      name: 'category',
+      title: 'Service Category',
+      type: 'string',
+      description: 'Category/group for organizing services in the menu',
+      options: {
+        list: [
+          { title: 'Formulation Services', value: 'formulation' },
+          { title: 'Research & Development', value: 'research' },
+          { title: 'Testing & Analysis', value: 'testing' },
+          { title: 'Consulting', value: 'consulting' }
+        ]
+      }
+    },
+    // SEO Fields
+    {
+      name: 'seo',
+      title: 'SEO Settings',
+      type: 'object',
+      fields: [
+        {
+          name: 'metaTitle',
+          title: 'Meta Title',
+          type: 'string',
+          description: 'Title that appears in search engines (optimal: 50-60 characters)',
+          components: {
+            input: (props: any) => {
+              const React = require('react')
+              const { set, unset } = require('sanity')
+              
+              const count = props.value ? props.value.length : 0
+              
+              // Extract only DOM-appropriate props
+              const { placeholder, disabled, readOnly, id } = props
+              
+              return React.createElement('div', null,
+                React.createElement('input', {
+                  placeholder,
+                  disabled,
+                  readOnly,
+                  id,
+                  value: props.value || '',
+                  onChange: (e: any) => props.onChange(e.target.value ? set(e.target.value) : unset()),
+                  style: {
+                    width: '100%',
+                    padding: '8px 12px',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '4px',
+                    fontSize: '14px'
+                  }
+                }),
+                React.createElement('div', {
+                  style: {
+                    fontSize: '12px',
+                    color: '#666',
+                    marginTop: '4px'
+                  }
+                }, `(${count} characters)`)
+              )
+            }
+          }
+        },
+        {
+          name: 'metaDescription',
+          title: 'Meta Description',
+          type: 'text',
+          rows: 3,
+          description: 'Description that appears in search engines (optimal: 140-155 characters)',
+          components: {
+            input: (props: any) => {
+              const React = require('react')
+              const { set, unset } = require('sanity')
+              
+              const count = props.value ? props.value.length : 0
+              
+              // Extract only DOM-appropriate props
+              const { placeholder, disabled, readOnly, id } = props
+              
+              return React.createElement('div', null,
+                React.createElement('textarea', {
+                  placeholder,
+                  disabled,
+                  readOnly,
+                  id,
+                  value: props.value || '',
+                  onChange: (e: any) => props.onChange(e.target.value ? set(e.target.value) : unset()),
+                  rows: 3,
+                  style: {
+                    width: '100%',
+                    padding: '8px 12px',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '4px',
+                    fontSize: '14px',
+                    fontFamily: 'inherit',
+                    resize: 'vertical'
+                  }
+                }),
+                React.createElement('div', {
+                  style: {
+                    fontSize: '12px',
+                    color: '#666',
+                    marginTop: '4px'
+                  }
+                }, `(${count} characters)`)
+              )
+            }
+          }
+        },
+        {
+          name: 'noIndex',
+          title: 'No Index',
+          type: 'boolean',
+          description: 'Prevent search engines from indexing this page',
+          initialValue: false
+        }
+      ],
+      options: {
+        collapsible: true,
+        collapsed: false
+      }
+    },
+    // Hero Section
+    {
+      name: 'hero',
+      title: 'Hero Section',
+      type: 'object',
+      fields: [
+        {
+          name: 'subheading',
+          title: 'Subheading',
+          type: 'string',
+          description: 'Small text above the main heading'
+        },
+        {
+          name: 'heading',
+          title: 'Main Heading',
+          type: 'string'
+        },
+        {
+          name: 'description',
+          title: 'Description',
+          type: 'text'
+        },
+        {
+          name: 'ctaText',
+          title: 'CTA Button Text',
+          type: 'string',
+          description: 'Text for the call-to-action button'
+        },
+        {
+          name: 'ctaUrl',
+          title: 'CTA Button URL',
+          type: 'string',
+          description: 'URL for the call-to-action button (e.g., Calendly link)'
+        },
+        {
+          name: 'image',
+          title: 'Hero Image',
+          type: 'image',
+          options: {
+            hotspot: true
+          }
+        },
+        {
+          name: 'imageAlt',
+          title: 'Image Alt Text',
+          type: 'string'
+        }
+      ]
+    },
+    // Features Overview (first how it works section)
+    {
+      name: 'featuresOverview',
+      title: 'Features Overview Section',
+      type: 'object',
+      fields: [
+        {
+          name: 'items',
+          title: 'Feature Items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              fields: [
+                {
+                  name: 'image',
+                  title: 'Feature Image',
+                  type: 'image'
+                },
+                {
+                  name: 'imageAlt',
+                  title: 'Image Alt Text',
+                  type: 'string'
+                },
+                {
+                  name: 'title',
+                  title: 'Feature Title',
+                  type: 'string'
+                },
+                {
+                  name: 'description',
+                  title: 'Feature Description',
+                  type: 'text'
+                }
+              ]
+            }
+          ],
+          validation: (Rule: any) => Rule.max(6)
+        }
+      ]
+    },
+    // Value Section (Why Choose Us)
+    {
+      name: 'value',
+      title: 'Value Proposition Section',
+      type: 'object',
+      fields: [
+        {
+          name: 'heading',
+          title: 'Heading',
+          type: 'string'
+        },
+        {
+          name: 'description',
+          title: 'Description',
+          type: 'text'
+        },
+        {
+          name: 'image',
+          title: 'Value Image',
+          type: 'image',
+          options: {
+            hotspot: true
+          }
+        },
+        {
+          name: 'imageAlt',
+          title: 'Image Alt Text',
+          type: 'string'
+        }
+      ]
+    },
+    // Service Specialties Section (Slider)
+    {
+      name: 'specialties',
+      title: 'Service Specialties Section',
+      type: 'object',
+      fields: [
+        {
+          name: 'heading',
+          title: 'Section Heading',
+          type: 'string'
+        },
+        {
+          name: 'description',
+          title: 'Section Description',
+          type: 'text'
+        },
+        {
+          name: 'items',
+          title: 'Specialty Items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              fields: [
+                {
+                  name: 'image',
+                  title: 'Specialty Image',
+                  type: 'image'
+                },
+                {
+                  name: 'imageAlt',
+                  title: 'Image Alt Text',
+                  type: 'string'
+                },
+                {
+                  name: 'title',
+                  title: 'Specialty Title',
+                  type: 'string'
+                },
+                {
+                  name: 'description',
+                  title: 'Specialty Description',
+                  type: 'text'
+                }
+              ]
+            }
+          ],
+          validation: (Rule: any) => Rule.max(8)
+        }
+      ]
+    },
+    // Process Section (How It Works - detailed process)
+    {
+      name: 'process',
+      title: 'Process Section (How It Works)',
+      type: 'object',
+      fields: [
+        {
+          name: 'title',
+          title: 'Section Title',
+          type: 'string'
+        },
+        {
+          name: 'description',
+          title: 'Section Description',
+          type: 'text'
+        },
+        {
+          name: 'steps',
+          title: 'Process Steps',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              fields: [
+                {
+                  name: 'image',
+                  title: 'Step Image',
+                  type: 'image'
+                },
+                {
+                  name: 'imageAlt',
+                  title: 'Image Alt Text',
+                  type: 'string'
+                },
+                {
+                  name: 'title',
+                  title: 'Step Title',
+                  type: 'string'
+                },
+                {
+                  name: 'description',
+                  title: 'Step Description',
+                  type: 'text'
+                }
+              ]
+            }
+          ],
+          validation: (Rule: any) => Rule.max(6)
+        }
+      ]
+    },
+    // Top CTA Row
+    {
+      name: 'topCTA',
+      title: 'Top Call to Action Row',
+      type: 'object',
+      fields: [
+        {
+          name: 'text',
+          title: 'CTA Text',
+          type: 'string'
+        },
+        {
+          name: 'url',
+          title: 'CTA URL',
+          type: 'string',
+          description: 'URL for the CTA link'
+        }
+      ]
+    },
+    // Product Range Section
+    {
+      name: 'productRange',
+      title: 'Product Range Section',
+      type: 'object',
+      fields: [
+        {
+          name: 'heading',
+          title: 'Section Heading',
+          type: 'string'
+        },
+        {
+          name: 'description',
+          title: 'Section Description',
+          type: 'text'
+        },
+        {
+          name: 'items',
+          title: 'Product Range Items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              fields: [
+                {
+                  name: 'image',
+                  title: 'Product Image',
+                  type: 'image'
+                },
+                {
+                  name: 'imageAlt',
+                  title: 'Image Alt Text',
+                  type: 'string'
+                },
+                {
+                  name: 'title',
+                  title: 'Product Category Title',
+                  type: 'string'
+                },
+                {
+                  name: 'description',
+                  title: 'Product Description',
+                  type: 'text'
+                }
+              ]
+            }
+          ],
+          validation: (Rule: any) => Rule.max(8)
+        }
+      ]
+    },
+    // Middle CTA Section
+    {
+      name: 'middleCTA',
+      title: 'Middle Call to Action Section',
+      type: 'object',
+      fields: [
+        {
+          name: 'subheading',
+          title: 'Subheading',
+          type: 'string'
+        },
+        {
+          name: 'heading',
+          title: 'Main Heading',
+          type: 'string'
+        },
+        {
+          name: 'ctaText',
+          title: 'CTA Button Text',
+          type: 'string'
+        },
+        {
+          name: 'ctaUrl',
+          title: 'CTA Button URL',
+          type: 'string'
+        },
+        {
+          name: 'image',
+          title: 'CTA Image',
+          type: 'image',
+          options: {
+            hotspot: true
+          }
+        },
+        {
+          name: 'imageAlt',
+          title: 'Image Alt Text',
+          type: 'string'
+        }
+      ]
+    },
+    // FAQ Section
+    {
+      name: 'faq',
+      title: 'FAQ Section',
+      type: 'object',
+      fields: [
+        {
+          name: 'title',
+          title: 'Section Title',
+          type: 'string'
+        },
+        {
+          name: 'subtitle',
+          title: 'Section Subtitle',
+          type: 'string'
+        },
+        {
+          name: 'items',
+          title: 'FAQ Items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              fields: [
+                {
+                  name: 'question',
+                  title: 'Question',
+                  type: 'string'
+                },
+                {
+                  name: 'answer',
+                  title: 'Answer',
+                  type: 'text'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    // Bottom CTA Section
+    {
+      name: 'bottomCTA',
+      title: 'Bottom Call to Action',
+      type: 'object',
+      fields: [
+        {
+          name: 'text',
+          title: 'CTA Text',
+          type: 'string'
+        },
+        {
+          name: 'buttonText',
+          title: 'Button Text',
+          type: 'string'
+        },
+        {
+          name: 'url',
+          title: 'CTA URL',
+          type: 'string'
+        }
+      ]
+    }
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'seo.metaTitle',
+      media: 'hero.image'
+    },
+    prepare(selection: any) {
+      const { title, subtitle, media } = selection
+      return {
+        title: title,
+        subtitle: subtitle ? `SEO: ${subtitle}` : 'No SEO title set',
+        media: media
+      }
+    }
+  }
+}
+
+export default service

--- a/types/Service.ts
+++ b/types/Service.ts
@@ -1,0 +1,94 @@
+import { PortableTextBlock } from "sanity"
+
+export type Service = {
+  _id: string
+  _createdAt: Date
+  name: string
+  slug: string
+  menuName?: string
+  showInMenu?: boolean
+  category?: 'formulation' | 'research' | 'testing' | 'consulting'
+  seo?: {
+    metaTitle: string
+    metaDescription: string
+    noIndex: boolean
+  }
+  hero?: {
+    subheading?: string
+    heading?: string
+    description?: string
+    ctaText?: string
+    ctaUrl?: string
+    image?: string
+    imageAlt?: string
+  }
+  featuresOverview?: {
+    items: Array<{
+      image: string
+      imageAlt: string
+      title: string
+      description: string
+    }>
+  }
+  value?: {
+    heading: string
+    description: string
+    image: string
+    imageAlt: string
+  }
+  specialties?: {
+    heading: string
+    description: string
+    items: Array<{
+      image: string
+      imageAlt: string
+      title: string
+      description: string
+    }>
+  }
+  process?: {
+    title: string
+    description: string
+    steps: Array<{
+      image: string
+      imageAlt: string
+      title: string
+      description: string
+    }>
+  }
+  topCTA?: {
+    text: string
+    url: string
+  }
+  productRange?: {
+    heading: string
+    description: string
+    items: Array<{
+      image: string
+      imageAlt: string
+      title: string
+      description: string
+    }>
+  }
+  middleCTA?: {
+    subheading: string
+    heading: string
+    ctaText: string
+    ctaUrl: string
+    image: string
+    imageAlt: string
+  }
+  faq?: {
+    title: string
+    subtitle: string
+    items: Array<{
+      question: string
+      answer: string
+    }>
+  }
+  bottomCTA?: {
+    text: string
+    buttonText: string
+    url: string
+  }
+}


### PR DESCRIPTION
- Create service schema and TypeScript types for Sanity CMS
- Add service pages with dynamic routing (/services/[service])
- Implement service listing page with categorization
- Build reusable service components (Hero, FAQ, CTA, Specialties, etc.)
- Add services to HTML and XML sitemaps for SEO
- Include services in Published URLs management
- Add FAQ schema for structured data
- Fix React Hooks violations and TypeScript errors
- Ensure responsive design and mobile touch support for sliders