### PR TITLE
feat: implement services navigation menu and redesign services page

### DIFF
--- a/app/(site)/services/components/ServiceGrid.module.css
+++ b/app/(site)/services/components/ServiceGrid.module.css
@@ -1,0 +1,189 @@
+/* Service Grid Section */
+.serviceGrid {
+  padding: 4rem 0;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.serviceGridContainer {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.gridContainer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 2rem;
+}
+
+/* Service Card */
+.serviceCard {
+  background: white;
+  border-radius: 16px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.serviceCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  border-color: var(--color-primary);
+}
+
+/* Image Container */
+.imageContainer {
+  position: relative;
+  width: 100%;
+  height: 250px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+}
+
+.serviceImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.serviceCard:hover .serviceImage {
+  transform: scale(1.05);
+}
+
+.imagePlaceholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--color-light) 0%, #e2e8f0 100%);
+  color: var(--color-gray);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+/* Card Content */
+.cardContent {
+  padding: 1.5rem;
+}
+
+.serviceTitle {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-dark);
+  margin-bottom: 0.75rem;
+  line-height: 1.3;
+}
+
+.serviceDescription {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--color-gray);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* CTA Container */
+.ctaContainer {
+  margin-top: auto;
+}
+
+.ctaText {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  transition: all 0.3s ease;
+}
+
+.serviceCard:hover .ctaText {
+  color: var(--color-secondary);
+}
+
+.arrowIcon {
+  transition: transform 0.3s ease;
+}
+
+.serviceCard:hover .arrowIcon {
+  transform: translateX(4px);
+}
+
+/* Empty State */
+.emptyState {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 4rem 2rem;
+}
+
+.emptyState h3 {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  color: var(--color-dark);
+  margin-bottom: 1rem;
+}
+
+.emptyState p {
+  font-family: var(--font-body);
+  color: var(--color-gray);
+  font-size: 1rem;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .serviceGrid {
+    padding: 2rem 0;
+  }
+  
+  .serviceGridContainer {
+    padding: 0 1rem;
+  }
+  
+  .gridContainer {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .cardContent {
+    padding: 1.25rem;
+  }
+  
+  .serviceTitle {
+    font-size: 1.25rem;
+  }
+  
+  .serviceDescription {
+    font-size: 0.9rem;
+    -webkit-line-clamp: 2;
+  }
+}
+
+@media (max-width: 480px) {
+  .imageContainer {
+    height: 200px;
+  }
+  
+  .cardContent {
+    padding: 1rem;
+  }
+  
+  .serviceTitle {
+    font-size: 1.125rem;
+    margin-bottom: 0.5rem;
+  }
+  
+  .serviceDescription {
+    margin-bottom: 1rem;
+  }
+}

--- a/app/(site)/services/components/ServiceGrid.tsx
+++ b/app/(site)/services/components/ServiceGrid.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { Service } from '@/types/Service'
+import styles from './ServiceGrid.module.css'
+
+interface ServiceGridProps {
+  services: Service[]
+}
+
+export default function ServiceGrid({ services }: ServiceGridProps) {
+  // Handle empty state
+  if (!services || services.length === 0) {
+    return (
+      <section className={styles.serviceGrid}>
+        <div className={styles.gridContainer}>
+          <div className={styles.emptyState}>
+            <h3>No Services Available</h3>
+            <p>We&apos;re working on adding new services. Please check back soon or contact us for custom solutions.</p>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  const renderService = (service: Service) => {
+    // Get service image and details from hero section
+    const serviceImage = service.hero?.image
+    const serviceImageAlt = service.hero?.imageAlt || `${service.name} service image`
+    const serviceHeading = service.hero?.heading || service.name
+    const serviceDescription = service.hero?.description || `Discover our ${service.name} solutions`
+
+    return (
+      <Link 
+        key={service._id} 
+        href={`/services/${service.slug}`}
+        className={styles.serviceCard}
+      >
+        <div className={styles.imageContainer}>
+          {serviceImage ? (
+            <Image
+              src={serviceImage}
+              alt={serviceImageAlt}
+              width={400}
+              height={250}
+              className={styles.serviceImage}
+            />
+          ) : (
+            <div className={styles.imagePlaceholder}>
+              <span>No Image Available</span>
+            </div>
+          )}
+        </div>
+        
+        <div className={styles.cardContent}>
+          <h3 className={styles.serviceTitle}>{serviceHeading}</h3>
+          <p className={styles.serviceDescription}>{serviceDescription}</p>
+          <div className={styles.ctaContainer}>
+            <span className={styles.ctaText}>
+              Learn more about this service
+              <svg 
+                className={styles.arrowIcon} 
+                width="16" 
+                height="16" 
+                viewBox="0 0 24 24" 
+                fill="none" 
+                stroke="currentColor" 
+                strokeWidth="2"
+              >
+                <path d="M5 12h14M12 5l7 7-7 7" />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </Link>
+    )
+  }
+
+  return (
+    <section className={styles.serviceGrid}>
+      <div className={styles.serviceGridContainer}>
+        <div className={styles.gridContainer}>
+          {services.map(renderService)}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/(site)/services/page.tsx
+++ b/app/(site)/services/page.tsx
@@ -1,177 +1,52 @@
-'use client'
-
 import { getServices } from '@/sanity/sanity-utils'
-import { Service } from '@/types/Service'
-import Link from 'next/link'
-import Image from 'next/image'
+import { Metadata } from 'next'
 import Breadcrumb from '@/app/components/Breadcrumb/Breadcrumb'
-import PageHero from '@/app/components/PageHero/PageHero'
-import { useEffect, useState } from 'react'
+import PageHero from "@/app/components/PageHero"
+import ServiceGrid from './components/ServiceGrid'
 
-export default function ServicesPage() {
-  const [services, setServices] = useState<Service[]>([])
-  const [loading, setLoading] = useState(true)
+export const metadata: Metadata = {
+  title: 'Our Services - Cosmetic Formulation & Manufacturing',
+  description: 'Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life.',
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    title: 'Our Services - Cosmetic Formulation & Manufacturing',
+    description: 'Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life.',
+    url: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://www.elixderm.com'}/services`,
+    siteName: 'Elixderm',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Our Services - Cosmetic Formulation & Manufacturing',
+    description: 'Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life.',
+  },
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://www.elixderm.com'}/services`,
+  },
+}
 
-  useEffect(() => {
-    // Set metadata
-    document.title = 'Our Services | Elixderm'
-    const metaDescription = document.querySelector('meta[name="description"]')
-    if (metaDescription) {
-      metaDescription.setAttribute('content', 'Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life.')
-    }
-
-    // Fetch services
-    getServices().then((data) => {
-      setServices(data)
-      setLoading(false)
-    })
-  }, [])
+export default async function ServicesPage() {
+  const services = await getServices()
 
   const breadcrumbItems = [
     { label: 'Home', href: '/' },
     { label: 'Services' }
   ]
 
-  // Group services by category
-  const groupedServices = services.reduce((acc, service) => {
-    const category = service.category || 'other'
-    if (!acc[category]) {
-      acc[category] = []
-    }
-    acc[category].push(service)
-    return acc
-  }, {} as Record<string, Service[]>)
-
-  const categoryLabels: Record<string, string> = {
-    formulation: 'Formulation Services',
-    research: 'Research & Development',
-    testing: 'Testing & Analysis',
-    consulting: 'Consulting',
-    other: 'Other Services'
-  }
-
-  if (loading) {
-    return (
-      <div className="services-page">
-        <Breadcrumb items={breadcrumbItems} />
-        <PageHero 
-          title="Our Services"
-          subtitle="Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life."
-        />
-        <main className="services-main" style={{ maxWidth: '1400px', margin: '0 auto', padding: '2rem', textAlign: 'center' }}>
-          <p>Loading services...</p>
-        </main>
-      </div>
-    )
-  }
-
   return (
     <div className="services-page">
       <Breadcrumb items={breadcrumbItems} />
       
-      <PageHero 
-        title="Our Services"
-        subtitle="Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life."
-      />
-      
-      <main className="services-main" style={{ maxWidth: '1400px', margin: '0 auto', padding: '2rem' }}>
-        {Object.entries(groupedServices).map(([category, categoryServices]) => (
-          <section key={category} style={{ marginBottom: '4rem' }}>
-            <h2 style={{ 
-              fontSize: '2rem', 
-              marginBottom: '2rem', 
-              color: '#1d413c',
-              textAlign: 'center'
-            }}>
-              {categoryLabels[category] || 'Services'}
-            </h2>
-            
-            <div style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-              gap: '2rem',
-              marginBottom: '3rem'
-            }}>
-              {categoryServices.map((service) => (
-                <Link 
-                  key={service._id}
-                  href={`/services/${service.slug}`}
-                  style={{
-                    textDecoration: 'none',
-                    color: 'inherit',
-                    border: '1px solid #e4e6e8',
-                    borderRadius: '15px',
-                    overflow: 'hidden',
-                    transition: 'transform 0.3s ease, box-shadow 0.3s ease',
-                    display: 'block'
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.transform = 'translateY(-5px)'
-                    e.currentTarget.style.boxShadow = '0 10px 25px rgba(29, 65, 60, 0.1)'
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.transform = 'translateY(0)'
-                    e.currentTarget.style.boxShadow = 'none'
-                  }}
-                >
-                  <div>
-                    {service.hero?.image && (
-                      <div style={{ height: '200px', overflow: 'hidden' }}>
-                        <Image
-                          src={service.hero.image}
-                          alt={service.hero.imageAlt || service.name}
-                          width={400}
-                          height={200}
-                          style={{
-                            width: '100%',
-                            height: '100%',
-                            objectFit: 'cover'
-                          }}
-                        />
-                      </div>
-                    )}
-                    
-                    <div style={{ padding: '1.5rem' }}>
-                      <h3 style={{
-                        fontSize: '1.5rem',
-                        marginBottom: '1rem',
-                        color: '#1d413c'
-                      }}>
-                        {service.name}
-                      </h3>
-                      
-                      {service.hero?.description && (
-                        <p style={{
-                          color: '#666',
-                          lineHeight: '1.6',
-                          marginBottom: '1rem'
-                        }}>
-                          {service.hero.description.substring(0, 150)}
-                          {service.hero.description.length > 150 ? '...' : ''}
-                        </p>
-                      )}
-                      
-                      <span style={{
-                        color: '#1d413c',
-                        fontWeight: 'bold',
-                        fontSize: '1rem'
-                      }}>
-                        Learn More →
-                      </span>
-                    </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </section>
-        ))}
+      <main className="services-page-main">
+        <PageHero 
+          title="Our Services" 
+          subtitle="Discover our comprehensive range of cosmetic formulation services designed to bring your beauty vision to life."
+        />
         
-        {services.length === 0 && (
-          <div style={{ textAlign: 'center', padding: '4rem 0' }}>
-            <h3 style={{ color: '#666' }}>No services available at the moment.</h3>
-            <p style={{ color: '#999' }}>Please check back later for updates.</p>
-          </div>
-        )}
+        <ServiceGrid services={services} />
       </main>
     </div>
   )

--- a/app/components/Navigation/Navigation.tsx
+++ b/app/components/Navigation/Navigation.tsx
@@ -4,16 +4,21 @@ import Link from 'next/link'
 import { useState, useEffect, useRef } from 'react'
 import { usePathname } from 'next/navigation'
 import ProductsMegaMenu from '@/app/components/ProductsMegaMenu'
+import ServicesMegaMenu from '@/app/components/ServicesMegaMenu'
 import styles from './Navigation.module.css'
-import { getMenuProducts } from '@/sanity/sanity-utils'
+import { getMenuProducts, getMenuServices } from '@/sanity/sanity-utils'
 import { Product } from '@/types/Product'
+import { Service } from '@/types/Service'
 
 export default function Navigation() {
   const pathname = usePathname()
   const [isProductsMenuOpen, setIsProductsMenuOpen] = useState(false)
+  const [isServicesMenuOpen, setIsServicesMenuOpen] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [menuProducts, setMenuProducts] = useState<Product[]>([])
+  const [menuServices, setMenuServices] = useState<Service[]>([])
   const productsMenuRef = useRef<HTMLLIElement>(null)
+  const servicesMenuRef = useRef<HTMLLIElement>(null)
   const navRef = useRef<HTMLElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -22,11 +27,26 @@ export default function Navigation() {
       clearTimeout(timeoutRef.current)
     }
     setIsProductsMenuOpen(true)
+    setIsServicesMenuOpen(false)
   }
 
   const handleProductsMenuLeave = () => {
     timeoutRef.current = setTimeout(() => {
       setIsProductsMenuOpen(false)
+    }, 150) // Small delay to prevent flickering
+  }
+
+  const handleServicesMenuEnter = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+    setIsServicesMenuOpen(true)
+    setIsProductsMenuOpen(false)
+  }
+
+  const handleServicesMenuLeave = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsServicesMenuOpen(false)
     }, 150) // Small delay to prevent flickering
   }
 
@@ -37,24 +57,35 @@ export default function Navigation() {
   const closeMobileMenu = () => {
     setIsMobileMenuOpen(false)
     setIsProductsMenuOpen(false)
+    setIsServicesMenuOpen(false)
   }
 
   const toggleProductsMobile = () => {
     setIsProductsMenuOpen(!isProductsMenuOpen)
+    setIsServicesMenuOpen(false)
   }
 
-  // Fetch menu products on component mount
+  const toggleServicesMobile = () => {
+    setIsServicesMenuOpen(!isServicesMenuOpen)
+    setIsProductsMenuOpen(false)
+  }
+
+  // Fetch menu products and services on component mount
   useEffect(() => {
-    async function fetchMenuProducts() {
+    async function fetchMenuData() {
       try {
-        const products = await getMenuProducts()
+        const [products, services] = await Promise.all([
+          getMenuProducts(),
+          getMenuServices()
+        ])
         setMenuProducts(products)
+        setMenuServices(services)
       } catch (error) {
-        console.error('Failed to fetch menu products:', error)
+        console.error('Failed to fetch menu data:', error)
       }
     }
     
-    fetchMenuProducts()
+    fetchMenuData()
   }, [])
 
   // Close menus when clicking outside the navbar
@@ -66,11 +97,17 @@ export default function Navigation() {
       if (!clickedInsideNav) {
         setIsMobileMenuOpen(false)
         setIsProductsMenuOpen(false)
+        setIsServicesMenuOpen(false)
       }
 
-      // Also collapse products submenu when clicking anywhere outside its li
-      if (productsMenuRef.current && !productsMenuRef.current.contains(targetNode)) {
-        setIsProductsMenuOpen(false)
+      // Also collapse submenus when clicking anywhere outside their li elements (only on desktop)
+      if (window.innerWidth > 768) {
+        if (productsMenuRef.current && !productsMenuRef.current.contains(targetNode)) {
+          setIsProductsMenuOpen(false)
+        }
+        if (servicesMenuRef.current && !servicesMenuRef.current.contains(targetNode)) {
+          setIsServicesMenuOpen(false)
+        }
       }
     }
 
@@ -93,6 +130,7 @@ export default function Navigation() {
   useEffect(() => {
     setIsMobileMenuOpen(false)
     setIsProductsMenuOpen(false)
+    setIsServicesMenuOpen(false)
   }, [pathname])
 
   return (
@@ -115,6 +153,36 @@ export default function Navigation() {
         <ul id="nav-menu" className={`nav-menu ${isMobileMenuOpen ? 'active' : ''}`}>
           <li 
             className={`nav-item ${styles.navItemWithDropdown}`}
+            ref={servicesMenuRef}
+            onMouseEnter={handleServicesMenuEnter}
+            onMouseLeave={handleServicesMenuLeave}
+          >
+            <Link 
+              href="/services" 
+              className={`nav-link ${styles.navLinkWithDropdown}`}
+              onClick={(e) => {
+                if (window.innerWidth <= 768) {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  toggleServicesMobile()
+                } else {
+                  closeMobileMenu()
+                }
+              }}
+            >
+              Services
+              <span className={styles.dropdownArrow}>⌄</span>
+            </Link>
+            
+            <ServicesMegaMenu
+              services={menuServices}
+              isOpen={isServicesMenuOpen}
+              onClose={closeMobileMenu}
+            />
+          </li>
+          
+          <li 
+            className={`nav-item ${styles.navItemWithDropdown}`}
             ref={productsMenuRef}
             onMouseEnter={handleProductsMenuEnter}
             onMouseLeave={handleProductsMenuLeave}
@@ -125,6 +193,7 @@ export default function Navigation() {
               onClick={(e) => {
                 if (window.innerWidth <= 768) {
                   e.preventDefault()
+                  e.stopPropagation()
                   toggleProductsMobile()
                 } else {
                   closeMobileMenu()
@@ -135,11 +204,11 @@ export default function Navigation() {
               <span className={styles.dropdownArrow}>⌄</span>
             </Link>
             
-                             <ProductsMegaMenu
-                   products={menuProducts}
-                   isOpen={isProductsMenuOpen}
-                   onClose={closeMobileMenu}
-                 />
+            <ProductsMegaMenu
+              products={menuProducts}
+              isOpen={isProductsMenuOpen}
+              onClose={closeMobileMenu}
+            />
           </li>
           
           <li className="nav-item">

--- a/app/components/ProductFAQ/ProductFAQ.module.css
+++ b/app/components/ProductFAQ/ProductFAQ.module.css
@@ -37,6 +37,7 @@
 }
 
 .faqQuestion {
+  width: 100%;
   text-align: left;
   border: none;
   padding: 30px;
@@ -45,18 +46,21 @@
   font-size: 16px !important;
   margin-bottom: 0 !important;
   color: #626262;
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
 }
 
 .faqAnswer {
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.4s ease;
-  padding: 0 0 0px 75px;
+  padding: 0 0 0px 73px;
 }
 
 .faqItem.active .faqAnswer {
   max-height: 200px;
-  padding: 0 0 30px 75px;
+  padding: 0 0 30px 73px;
   margin-bottom: 20px;
 }
 
@@ -65,17 +69,22 @@
 }
 
 .toggleIcon {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: 0.3s ease;
   background: #e4e6e8;
   font-weight: 200;
   font-size: 20px;
-  margin-right: 10px;
   border-radius: 50%;
   width: 28px;
   height: 28px;
-  text-align: center;
-  line-height: 28px;
+  flex-shrink: 0;
+}
+
+.faqQuestion span:last-child {
+  flex: 1;
+  line-height: 1.4;
 }
 
 @media screen and (max-width: 600px) {

--- a/app/components/ProductFAQ/ProductFAQ.tsx
+++ b/app/components/ProductFAQ/ProductFAQ.tsx
@@ -88,7 +88,7 @@ export default function ProductFAQ({ product }: ProductFAQProps) {
                 <span className={styles.toggleIcon}>
                   {activeItems.includes(index) ? '-' : '+'}
                 </span>
-                {faq.question}
+                <span>{faq.question}</span>
               </h3>
               <div 
                 className={styles.faqAnswer}

--- a/app/components/ProductsMegaMenu/ProductsMegaMenu.tsx
+++ b/app/components/ProductsMegaMenu/ProductsMegaMenu.tsx
@@ -75,7 +75,7 @@ export default function ProductsMegaMenu({
           // Only render column if it has products
           column.products.length > 0 && (
             <div key={columnIndex} className={styles.megaMenuColumn}>
-              <h4 className={styles.megaMenuTitle}>{column.title}</h4>
+              <p className={styles.megaMenuTitle}>{column.title}</p>
               <ul className={styles.megaMenuList}>
                 {column.products.map((product) => (
                   <li key={product._id}>

--- a/app/components/ServiceFAQ/ServiceFAQ.module.css
+++ b/app/components/ServiceFAQ/ServiceFAQ.module.css
@@ -44,33 +44,41 @@
   font-size: 16px !important;
   margin-bottom: 0 !important;
   color: #626262;
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
 }
 
 .faqAnswer {
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.4s ease;
-  padding: 0 0 0px 75px;
+  padding: 0 0 0px 73px;
 }
 
 .faqItem.active .faqAnswer {
   max-height: 200px;
-  padding: 0 0 30px 75px;
+  padding: 0 0 30px 73px;
   margin-bottom: 20px;
 }
 
 .toggleIcon {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: 0.3s ease;
   background: #e4e6e8;
   font-weight: 200;
   font-size: 20px;
-  margin-right: 10px;
   border-radius: 50%;
   width: 28px;
   height: 28px;
-  text-align: center;
-  line-height: 28px;
+  flex-shrink: 0;
+}
+
+.faqQuestion span:last-child {
+  flex: 1;
+  line-height: 1.4;
 }
 
 .answerContent {

--- a/app/components/ServiceFAQ/ServiceFAQ.tsx
+++ b/app/components/ServiceFAQ/ServiceFAQ.tsx
@@ -82,7 +82,7 @@ export default function ServiceFAQ({ service }: ServiceFAQProps) {
                 <span className={styles.toggleIcon}>
                   {activeItems.includes(index) ? '-' : '+'}
                 </span>
-                {item.question}
+                <span>{item.question}</span>
               </h3>
               <div className={styles.faqAnswer}>
                 <div className={styles.answerContent}>

--- a/app/components/ServiceHero/ServiceHero.module.css
+++ b/app/components/ServiceHero/ServiceHero.module.css
@@ -1,72 +1,142 @@
-/* Service Hero Styles based on the provided CSS */
+/* Professional Service Hero Styles */
 
 .heroContainer {
-  margin-top: 50px;
+  margin-top: 60px;
+  padding: 0 20px;
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .hero {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  background: linear-gradient(to right, #e4e6e8, white);
-  border-radius: 30px 0 0 30px;
+  background: linear-gradient(135deg, #f8fffe 0%, #e8f5f3 50%, #f0f9f7 100%);
+  border-radius: 24px;
+  box-shadow: 0 8px 32px rgba(16, 185, 129, 0.08);
+  overflow: hidden;
+  min-height: 600px;
+  position: relative;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, transparent 0%, rgba(16, 185, 129, 0.02) 100%);
+  pointer-events: none;
 }
 
 .left {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border-radius: 0 25% 0 0;
   width: 50%;
+  padding: 80px 60px;
+  position: relative;
+  z-index: 2;
 }
 
-.left p {
-  margin: 10px 0;
-  font-size: 1.125rem; /* 18px */
+.left p:first-child {
+  margin: 0 0 16px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #10b981;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  opacity: 0.9;
+}
+
+.left p:last-of-type {
+  margin: 24px 0 0 0;
+  font-size: 1.25rem;
+  line-height: 1.7;
+  color: #4b5563;
+  font-weight: 400;
 }
 
 .leftText {
-  margin: 10%;
+  margin: 0;
 }
 
 .left h1 {
-  margin: 10px 0;
-  font-size: 3.125rem; /* 50px */
+  margin: 0;
+  font-size: 3.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: #1f2937;
+  background: linear-gradient(135deg, #1f2937 0%, #374151 100%);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .heroCTAButton {
-  height: 47px;
-  line-height: 47px;
+  height: 56px;
+  line-height: 56px;
   border: none;
   cursor: pointer;
-  transition: 0.3s;
-  background-color: #10b981 !important;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
   color: white;
-  padding: 0 25px;
-  border-radius: 30px;
-  font-size: 1.125rem; /* 18px */
+  padding: 0 32px;
+  border-radius: 50px;
+  font-size: 1.125rem;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgba(16, 185, 129, 0.3);
+  position: relative;
+  overflow: hidden;
+}
+
+.heroCTAButton::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transition: left 0.6s;
+}
+
+.heroCTAButton:hover::before {
+  left: 100%;
 }
 
 .heroCTAButton:hover {
-  transform: translateY(-3px);
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
-  transition: 0.3s;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(16, 185, 129, 0.4);
+  background: linear-gradient(135deg, #059669 0%, #047857 100%);
 }
 
 .heroCTAButton:active {
-  transform: translateY(1px);
-  box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.8);
-  transition: 0.1s;
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
 }
 
 .right {
-  border-radius: 25% 0 0 0;
-  height: 500px;
+  width: 50%;
+  height: 600px;
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
-  width: 50%;
+}
+
+.right::before {
+  content: '';
+  position: absolute;
+  top: 20%;
+  right: 10%;
+  width: 200px;
+  height: 200px;
+  background: radial-gradient(circle, rgba(16, 185, 129, 0.1) 0%, transparent 70%);
+  border-radius: 50%;
+  z-index: 0;
 }
 
 .rightB {
@@ -75,60 +145,142 @@
   align-items: center;
   width: 100%;
   height: 100%;
+  position: relative;
+  padding: 40px;
 }
 
 .right img {
   mix-blend-mode: multiply;
   filter: brightness(1.03);
   max-height: 500px;
+  transition: transform 0.3s ease;
+}
+
+.right:hover img {
+  transform: scale(1.02);
 }
 
 .buttonsHolder {
-  margin-top: 12% !important;
+  margin-top: 40px;
   display: flex;
 }
 
+/* Tablet styles */
+@media screen and (max-width: 1024px) {
+  .heroContainer {
+    padding: 0 16px;
+  }
+
+  .left {
+    padding: 60px 40px;
+  }
+
+  .left h1 {
+    font-size: 3rem;
+  }
+
+  .left p:last-of-type {
+    font-size: 1.125rem;
+  }
+
+  .right {
+    height: 500px;
+  }
+
+  .right img {
+    max-height: 400px;
+  }
+}
+
 /* Mobile styles */
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 768px) {
+  .heroContainer {
+    margin-top: 20px;
+    padding: 0 12px;
+  }
+
   .hero {
     flex-direction: column-reverse;
-    background: #e4e6e8;
-    border-radius: 0 0 30px 30px;
+    min-height: auto;
+    border-radius: 20px;
   }
 
   .right {
     width: 100%;
-    border-radius: 0 0 0 25%;
     height: 300px;
   }
 
+  .right::before {
+    top: 10%;
+    right: 5%;
+    width: 120px;
+    height: 120px;
+  }
+
+  .rightB {
+    padding: 20px;
+  }
+
   .right img {
-    max-height: 300px;
-    margin-top: 15%;
+    max-height: 250px;
   }
 
   .left {
     width: 100%;
-    border-radius: 0 0 10% 10%;
+    padding: 40px 24px;
   }
 
   .left h1 {
-    font-size: 1.875rem; /* 30px */
+    font-size: 2.25rem;
+    line-height: 1.2;
   }
 
-  .left p {
-    font-size: 0.875rem; /* 14px */
+  .left p:first-child {
+    font-size: 0.875rem;
+    margin-bottom: 12px;
   }
 
-  .leftText {
-    margin: 15% 5% 8% 5%; /* Reduced margins */
+  .left p:last-of-type {
+    font-size: 1rem;
+    line-height: 1.6;
+    margin-top: 16px;
   }
 
-  .heroContainer {
-    margin-top: 5px;
+  .buttonsHolder {
+    margin-top: 32px;
   }
 
   .heroCTAButton {
-    font-size: 16px;
+    height: 48px;
+    line-height: 48px;
+    font-size: 1rem;
+    padding: 0 24px;
+    border-radius: 50px;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .left {
+    padding: 32px 20px;
+  }
+
+  .left h1 {
+    font-size: 1.875rem;
+  }
+
+  .left p:first-child {
+    font-size: 0.8125rem;
+  }
+
+  .left p:last-of-type {
+    font-size: 0.9375rem;
+  }
+
+  .heroCTAButton {
+    height: 44px;
+    line-height: 44px;
+    font-size: 0.9375rem;
+    padding: 0 20px;
+    border-radius: 50px;
   }
 }

--- a/app/components/ServiceMiddleCTA/ServiceMiddleCTA.module.css
+++ b/app/components/ServiceMiddleCTA/ServiceMiddleCTA.module.css
@@ -1,60 +1,98 @@
-/* Service Middle CTA Styles */
+/* Modern Service Middle CTA Styles */
 
 .middleCTA {
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-evenly;
-  background-color: #e4e6e8;
-  padding: 2% 0;
+  justify-content: space-between;
+  background: linear-gradient(135deg, #f8fffe 0%, #e8f5f3 50%, #f0f9f7 100%);
+  padding: 80px 60px;
   overflow: hidden;
-  z-index: 0;
-  margin-bottom: 50px;
+  margin: 80px 0;
+  border-radius: 24px;
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
+  box-shadow: 0 8px 32px rgba(16, 185, 129, 0.08);
 }
 
 .mctaText {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  max-width: 500px;
+  z-index: 2;
+  position: relative;
 }
 
 .mctaText p {
-  font-size: 1.125rem; /* 18px */
-  margin-bottom: 5px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #10b981;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 16px;
+  opacity: 0.9;
 }
 
 .mctaText h2 {
-  font-size: 2.5rem; /* 40px */
-  margin-bottom: 15px;
-}
-
-.mctaText button svg {
-  width: 70px;
-  height: 35px;
-  margin-left: 10px;
+  font-size: 2.75rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 32px;
+  line-height: 1.2;
 }
 
 .mctaText button {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  border: 2px solid #10b981 !important;
-  background-color: transparent !important;
-  color: #10b981 !important;
-  padding: 10px 20px;
+  justify-content: center;
+  gap: 12px;
+  border: 2px solid #10b981;
+  background: transparent;
+  color: #10b981;
+  padding: 16px 32px;
   cursor: pointer;
-  border-radius: 30px;
-  width: 70%;
-  transition: 0.3s;
-  font-size: 1.125rem; /* 18px */
+  border-radius: 50px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  font-size: 1.125rem;
+  font-weight: 600;
+  min-width: 200px;
+  position: relative;
+  overflow: hidden;
+}
+
+.mctaText button::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transition: left 0.6s;
+}
+
+.mctaText button:hover::before {
+  left: 100%;
 }
 
 .mctaText button:hover {
-  border: 2px solid transparent !important;
-  background-color: #10b981 !important;
-  color: white !important;
-  padding: 10px 20px;
-  width: 75%;
-  transition: 0.3s;
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  color: white;
+  border-color: #10b981;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(16, 185, 129, 0.3);
+}
+
+.mctaText button svg {
+  width: 32px;
+  height: 32px;
+  transition: transform 0.3s ease;
+}
+
+.mctaText button:hover svg {
+  transform: translateX(4px);
 }
 
 .mctaText button:hover svg line {
@@ -65,18 +103,26 @@
   fill: white;
 }
 
+.middleCTA > div:first-child {
+  position: relative;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 40px;
+}
+
 .blobContainer {
   position: absolute;
-  width: 350px;
-  height: 350px;
+  width: 300px;
+  height: 300px;
   z-index: 0;
-  left: 15%;
+  opacity: 0.3;
   transition: transform 0.3s ease;
-  display: none;
 }
 
 .middleCTA:hover .blobContainer {
-  transform: translate(-10px, -10px);
+  transform: rotate(10deg) scale(1.05);
 }
 
 .middleCTA img {
@@ -84,31 +130,103 @@
   z-index: 1;
   mix-blend-mode: multiply;
   filter: brightness(1.03);
+  max-width: 350px;
+  height: auto;
+  transition: transform 0.3s ease;
 }
 
-/* Mobile styles */
-@media screen and (max-width: 600px) {
+.middleCTA:hover img {
+  transform: scale(1.02);
+}
+
+/* Tablet styles */
+@media screen and (max-width: 1024px) {
   .middleCTA {
-    flex-direction: column;
-  }
-
-  .mctaText {
-    margin: 10% 5% 5% 5%;
-  }
-
-  .mctaText p {
-    font-size: 0.875rem; /* 14px on mobile */
-    margin-bottom: 20px;
-    line-height: 1.1;
+    padding: 60px 40px;
+    margin: 60px 20px;
   }
 
   .mctaText h2 {
-    line-height: 1.25;
+    font-size: 2.25rem;
+  }
+
+  .middleCTA > div:first-child {
+    margin-left: 20px;
+  }
+
+  .middleCTA img {
+    max-width: 300px;
+  }
+}
+
+/* Mobile styles */
+@media screen and (max-width: 768px) {
+  .middleCTA {
+    flex-direction: column;
+    padding: 48px 24px;
+    margin: 48px 12px;
+    text-align: center;
+    border-radius: 20px;
+  }
+
+  .middleCTA > div:first-child {
+    margin-left: 0;
+    margin-bottom: 32px;
+    order: -1;
+  }
+
+  .mctaText {
+    max-width: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .mctaText p {
+    font-size: 0.875rem;
+    margin-bottom: 12px;
+  }
+
+  .mctaText h2 {
+    font-size: 2rem;
+    margin-bottom: 24px;
+    line-height: 1.3;
   }
 
   .mctaText button {
-    width: 90%;
-    margin-top: 5%;
-    font-size: 15px;
+    min-width: 180px;
+    padding: 14px 28px;
+    font-size: 1rem;
+    align-self: center;
+  }
+
+  .middleCTA img {
+    max-width: 325px;
+  }
+
+  .blobContainer {
+    width: 200px;
+    height: 200px;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .middleCTA {
+    padding: 40px 20px;
+    margin: 40px 8px;
+  }
+
+  .mctaText h2 {
+    font-size: 1.75rem;
+  }
+
+  .mctaText button {
+    min-width: 160px;
+    padding: 12px 24px;
+    font-size: 0.9375rem;
+  }
+
+  .middleCTA img {
+    max-width: 260px;
   }
 }

--- a/app/components/ServiceSpecialties/ServiceSpecialties.module.css
+++ b/app/components/ServiceSpecialties/ServiceSpecialties.module.css
@@ -1,9 +1,13 @@
-/* Service Specialties Slider Styles */
+/* Modern Service Specialties Slider Styles */
 
 .imageSlider {
   position: relative;
   width: 100%;
-  margin: 70px 0;
+  margin: 80px 0;
+  padding: 0 20px;
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .hitContainer {
@@ -15,144 +19,244 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  margin: 0 15%;
+  margin: 0 auto 60px auto;
+  max-width: 800px;
 }
 
 .hitTitles h2 {
-  font-size: 2.5rem; /* 40px */
-  margin-bottom: 15px;
+  font-size: 2.75rem;
+  font-weight: 700;
+  margin-bottom: 20px;
+  color: #1f2937;
+  line-height: 1.2;
 }
 
 .hitTitles p {
-  font-size: 1.125rem; /* 18px */
+  font-size: 1.25rem;
+  color: #6b7280;
+  line-height: 1.6;
+  font-weight: 400;
 }
 
 .sliderContainer {
   overflow: hidden;
-  margin: 30px;
+  margin: 0 40px;
   position: relative;
-  touch-action: pan-x; /* Allow horizontal panning for swipe */
-  user-select: none; /* Prevent text selection during swipe */
+  touch-action: pan-x;
+  user-select: none;
 }
 
 .formulations {
   display: flex;
-  transition: transform 0.5s ease;
-  gap: 30px;
+  transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  gap: 32px;
   box-sizing: border-box;
 }
 
 .formulation {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  padding: 40px;
-  transition: 0.3s;
-  background: #e4e6e8;
-  border-radius: 30px 30px 0 0;
-  border-bottom: 3px solid #10b981;
+  align-items: center;
+  text-align: center;
+  padding: 48px 32px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  border-radius: 24px;
+  border: 1px solid #e2e8f0;
   box-sizing: border-box;
-  flex: 0 0 calc(33.333% - 20px); /* 3 items per row with gap */
-  width: calc(33.333% - 20px);
+  flex: 0 0 calc(33.333% - 22px);
+  width: calc(33.333% - 22px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+  position: relative;
+  overflow: hidden;
 }
 
+
+
 .formulation:hover {
-  background: #f0f2f4;
-  transition: 0.3s;
+  border-color: #10b981;
+}
+
+.formulation h3 {
+  font-size: 1.375rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 20px 0 12px 0;
+  line-height: 1.3;
+}
+
+.formulation p {
+  font-size: 1rem;
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0;
+  font-weight: 400;
 }
 
 .formulations img {
-  width: 75px;
-  margin-bottom: 15px;
-  height: auto;
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 8px rgba(16, 185, 129, 0.1));
+  transition: transform 0.3s ease;
+}
+
+.formulation:hover img {
+  transform: scale(1.1);
 }
 
 .prevF, .nextF {
   position: absolute;
-  top: calc(50% + 60px); /* Adjust to be in middle of cards (accounting for titles) */
+  top: calc(50% + 80px);
   transform: translateY(-50%);
-  font-size: 30px;
+  font-size: 20px;
   cursor: pointer;
-  background: #ffffffeb !important;
-  border: none !important;
-  color: #10b981 !important;
-  transition: 0.3s;
-  z-index: 2;
-  width: 50px;
-  height: 50px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  color: #10b981;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 3;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(8px);
 }
 
 .prevF { 
-  left: 10px;
+  left: -8px;
 }
 
 .nextF { 
-  right: 10px;
+  right: -8px;
 }
 
 .prevF:hover, .nextF:hover {
-  background: #10b981 !important;
-  color: #fff !important;
-  transition: 0.3s;
-  transform: translateY(-50%) scale(1.1);
+  background: #10b981;
+  color: #ffffff;
+  border-color: #10b981;
+  transform: translateY(-50%) scale(1.05);
+  box-shadow: 0 8px 24px rgba(16, 185, 129, 0.3);
 }
 
-/* Desktop and Tablet styles (769px and up) */
-@media screen and (min-width: 769px) {
-  .sliderContainer {
-    margin: 30px;
+.prevF:active, .nextF:active {
+  transform: translateY(-50%) scale(0.95);
+}
+
+/* Tablet styles */
+@media screen and (max-width: 1024px) {
+  .imageSlider {
+    padding: 0 16px;
   }
 
-  .formulation {
-    padding: 40px;
+  .sliderContainer {
+    margin: 0 24px;
+  }
+
+  .hitTitles h2 {
+    font-size: 2.25rem;
+  }
+
+  .hitTitles p {
+    font-size: 1.125rem;
   }
 }
 
 /* Mobile styles */
 @media screen and (max-width: 768px) {
+  .imageSlider {
+    margin: 60px 0;
+    padding: 0 12px;
+  }
+
   .sliderContainer {
-    margin: 20px;
+    margin: 0 16px;
   }
 
   .formulations {
-    gap: 20px;
+    gap: 24px;
   }
 
   .formulation {
-    padding: 30px 20px;
-    flex: 0 0 calc(100% - 20px); /* 1 item per row on mobile */
-    width: calc(100% - 20px);
+    padding: 40px 24px;
+    flex: 0 0 calc(100% - 24px);
+    width: calc(100% - 24px);
+    border-radius: 20px;
   }
 
   .hitTitles {
-    margin: 0 5%;
+    margin: 0 auto 48px auto;
+    max-width: none;
   }
 
   .hitTitles h2 {
-    font-size: 1.5625rem; /* 25px */
+    font-size: 2rem;
   }
 
   .hitTitles p {
-    font-size: 0.875rem; /* 14px on mobile */
+    font-size: 1rem;
+  }
+
+  .formulation h3 {
+    font-size: 1.25rem;
+    margin: 16px 0 10px 0;
+  }
+
+  .formulation p {
+    font-size: 0.9375rem;
+  }
+
+  .formulations img {
+    width: 70px;
+    height: 70px;
   }
 
   .prevF, .nextF {
-    width: 42px; /* 15% smaller than 50px = 42.5px */
-    height: 42px;
-    font-size: 25px; /* 15% smaller than 30px = 25.5px */
-    top: calc(50% + 40px); /* Adjust for mobile card height */
+    width: 48px;
+    height: 48px;
+    font-size: 18px;
+    top: calc(50% + 60px);
   }
 
   .prevF {
-    left: 5px;
+    left: -4px;
   }
 
   .nextF {
-    right: 5px;
+    right: -4px;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .imageSlider {
+    margin: 48px 0;
+  }
+
+  .hitTitles h2 {
+    font-size: 1.75rem;
+  }
+
+  .hitTitles p {
+    font-size: 0.9375rem;
+  }
+
+  .formulation {
+    padding: 32px 20px;
+  }
+
+  .formulation h3 {
+    font-size: 1.125rem;
+  }
+
+  .formulation p {
+    font-size: 0.875rem;
+  }
+
+  .formulations img {
+    width: 64px;
+    height: 64px;
   }
 }

--- a/app/components/ServicesMegaMenu/README.md
+++ b/app/components/ServicesMegaMenu/README.md
@@ -1,0 +1,61 @@
+# ServicesMegaMenu Component
+
+A full-width dropdown menu component that displays services in a grid layout with hover effects.
+
+## Features
+
+- **Full-width display**: Spans the entire viewport width
+- **Grid layout**: 4 columns on desktop, 2 on tablet, 1 on mobile
+- **Hover effects**: Interactive animations and color changes
+- **Theme integration**: Uses CSS variables for consistent theming
+- **Responsive design**: Adapts to different screen sizes
+- **Accessibility**: Keyboard navigation support
+
+## Props
+
+```typescript
+interface ServicesMegaMenuProps {
+  services: Service[]  // Array of service objects from Sanity
+  isOpen: boolean     // Controls menu visibility
+  onClose: () => void // Callback when menu should close
+}
+```
+
+## Service Object Structure
+
+Each service should have:
+- `_id`: Unique identifier
+- `name`: Service name
+- `slug`: URL slug for the service
+- `menuName`: Optional custom display name for menu
+- `menuDescription`: Short description for menu display
+
+## Usage
+
+```tsx
+import ServicesMegaMenu from '@/app/components/ServicesMegaMenu'
+
+<ServicesMegaMenu
+  services={menuServices}
+  isOpen={isServicesMenuOpen}
+  onClose={closeMobileMenu}
+/>
+```
+
+## Styling
+
+The component uses CSS modules with the following key classes:
+- `.servicesMegaMenu`: Main container
+- `.servicesMenuContent`: Grid container
+- `.serviceItem`: Individual service item
+- `.serviceTitle`: Service name with arrow
+- `.serviceDescription`: Service description text
+
+## Theme Colors
+
+Uses CSS custom properties:
+- `--color-primary`: Main green color (#10b981)
+- `--color-secondary`: Darker green (#059669)
+- `--color-dark`: Text color (#1f2937)
+- `--color-gray`: Muted text (#6b7280)
+- `--color-light`: Background hover (#f8fafc)

--- a/app/components/ServicesMegaMenu/ServicesMegaMenu.module.css
+++ b/app/components/ServicesMegaMenu/ServicesMegaMenu.module.css
@@ -1,0 +1,239 @@
+/* Services Mega Menu */
+.servicesMegaMenu {
+  position: fixed;
+  top: 80px; /* Adjust based on navbar height */
+  left: 0;
+  right: 0;
+  width: 100vw;
+  background: white;
+  border-radius: 0 0 12px 12px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1000;
+}
+
+.servicesMegaMenu.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.servicesMenuContent {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  padding: 40px 1.5rem;
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.serviceItem {
+  position: relative;
+  padding: 32px 24px;
+  margin: 0 12px;
+  transition: all 0.3s ease;
+}
+
+.serviceItem:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 20%;
+  right: -12px;
+  width: 1px;
+  height: 60%;
+  background: linear-gradient(to bottom, transparent, #e5e7eb, transparent);
+}
+
+.serviceItem:hover {
+  background: var(--color-light);
+  border-radius: 8px;
+}
+
+.serviceLink {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+}
+
+.serviceTitle {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-dark);
+  margin: 0 0 12px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: color 0.3s ease;
+}
+
+.serviceItem:hover .serviceTitle {
+  color: var(--color-primary);
+}
+
+.serviceArrow {
+  font-size: 16px;
+  color: var(--color-primary);
+  transition: all 0.3s ease;
+  opacity: 0.8;
+}
+
+.serviceItem:hover .serviceArrow {
+  color: var(--color-secondary);
+  opacity: 1;
+  transform: translateX(4px);
+}
+
+.serviceDescription {
+  font-size: 14px;
+  color: var(--color-gray);
+  line-height: 1.5;
+  margin: 0;
+  transition: color 0.3s ease;
+}
+
+.serviceItem:hover .serviceDescription {
+  color: var(--color-dark);
+}
+
+/* Mobile Styles */
+@media (max-width: 1024px) {
+  .servicesMegaMenu {
+    position: fixed;
+    top: 70px;
+    left: 0;
+    right: 0;
+    width: 100vw;
+  }
+  
+  .servicesMenuContent {
+    grid-template-columns: repeat(2, 1fr);
+    padding: 24px;
+    gap: 16px;
+  }
+  
+  .serviceItem {
+    padding: 20px 16px;
+  }
+  
+  .serviceItem:nth-child(odd)::after {
+    display: block;
+  }
+  
+  .serviceItem:nth-child(even)::after {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .servicesMegaMenu {
+    position: static;
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+    box-shadow: none;
+    background: transparent;
+    border-radius: 0;
+    border-top: none;
+    width: 100%;
+    max-width: 100vw;
+  }
+  
+  .servicesMenuContent {
+    grid-template-columns: 1fr;
+    padding: 0;
+    gap: 0;
+    width: 100%;
+    max-width: 100vw;
+    box-sizing: border-box;
+  }
+  
+  .serviceItem {
+    padding: 16px 0;
+    margin: 0;
+    border-bottom: 1px solid #e5e7eb;
+    width: 100%;
+    max-width: 380px;
+    box-sizing: border-box;
+  }
+  
+  .serviceItem:last-child {
+    border-bottom: none;
+  }
+  
+  .serviceItem::after {
+    display: none;
+  }
+  
+  .serviceItem:hover {
+    background: transparent;
+  }
+  
+  .serviceTitle {
+    font-size: 16px;
+    display: block;
+    width: 100%;
+    max-width: 380px;
+    box-sizing: border-box;
+  }
+  
+  .serviceArrow {
+    font-size: 14px;
+    margin-left: 8px;
+    display: inline;
+  }
+  
+  .serviceDescription {
+    font-size: 13px;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    width: 100%;
+    max-width: 380px;
+    box-sizing: border-box;
+  }
+}
+
+@media (max-width: 480px) {
+  .servicesMenuContent {
+    padding: 0;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100vw;
+  }
+  
+  .serviceItem {
+    padding: 12px 0;
+    margin: 0;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 380px;
+  }
+  
+  .serviceTitle {
+    font-size: 14px;
+    display: block;
+    margin-bottom: 8px;
+    width: 100%;
+    max-width: 380px;
+    box-sizing: border-box;
+  }
+  
+  .serviceArrow {
+    font-size: 12px;
+    margin-left: 6px;
+  }
+  
+  .serviceDescription {
+    font-size: 12px;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    line-height: 1.4;
+    width: 100%;
+    max-width: 380px;
+    box-sizing: border-box;
+  }
+}

--- a/app/components/ServicesMegaMenu/ServicesMegaMenu.tsx
+++ b/app/components/ServicesMegaMenu/ServicesMegaMenu.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import Link from 'next/link'
+import { Service } from '@/types/Service'
+import styles from './ServicesMegaMenu.module.css'
+
+interface ServicesMegaMenuProps {
+  services: Service[]
+  isOpen: boolean
+  onClose: () => void
+}
+
+export default function ServicesMegaMenu({ services, isOpen, onClose }: ServicesMegaMenuProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className={`${styles.servicesMegaMenu} ${isOpen ? styles.open : ''}`}>
+      <div className={styles.servicesMenuContent}>
+        {services.map((service) => (
+          <div key={service._id} className={styles.serviceItem}>
+            <Link 
+              href={`/services/${service.slug}`}
+              className={styles.serviceLink}
+              onClick={onClose}
+            >
+              <p className={styles.serviceTitle}>
+                {service.menuName || service.name}
+                <span className={styles.serviceArrow}>→</span>
+              </p>
+              <p className={styles.serviceDescription}>
+                {service.menuDescription || 'Learn more about this service'}
+              </p>
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/ServicesMegaMenu/index.ts
+++ b/app/components/ServicesMegaMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ServicesMegaMenu'

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -187,17 +187,21 @@ export async function getServices(): Promise<Service[]> {
     category,
     hero {
       heading,
-      description
+      description,
+      "image": image.asset->url,
+      imageAlt
     }
   }`);
 }
 
 export async function getMenuServices(): Promise<Service[]> {
-  return createClient(clientConfig).fetch(groq`*[_type == "service" && showInMenu == true] | order(category asc, name asc){
+  return createClient(clientConfig).fetch(groq`*[_type == "service" && showInMenu == true] | order(menuOrder asc, name asc){
     _id,
     name,
     "slug": slug.current,
     menuName,
+    menuDescription,
+    menuOrder,
     category
   }`);
 }

--- a/sanity/schemas/service-schema.ts
+++ b/sanity/schemas/service-schema.ts
@@ -27,11 +27,25 @@ const service = {
       description: 'Custom name to display in navigation menu (leave empty to use Service Name)'
     },
     {
+      name: 'menuDescription',
+      title: 'Menu Description',
+      type: 'text',
+      description: 'Short description to display in the services navigation menu',
+      rows: 2
+    },
+    {
       name: 'showInMenu',
       title: 'Show in Navigation Menu',
       type: 'boolean',
       description: 'Toggle to control if this service appears in the main navigation menu',
       initialValue: true
+    },
+    {
+      name: 'menuOrder',
+      title: 'Menu Order',
+      type: 'number',
+      description: 'Order in which this service appears in the menu (1-4, lower numbers appear first)',
+      validation: (Rule: any) => Rule.min(1).max(4)
     },
     {
       name: 'category',

--- a/types/Service.ts
+++ b/types/Service.ts
@@ -6,7 +6,9 @@ export type Service = {
   name: string
   slug: string
   menuName?: string
+  menuDescription?: string
   showInMenu?: boolean
+  menuOrder?: number
   category?: 'formulation' | 'research' | 'testing' | 'consulting'
   seo?: {
     metaTitle: string


### PR DESCRIPTION
- Add ServicesMegaMenu component with full-width dropdown matching reference design
- Create ServiceGrid component matching ProductGrid design
- Update Navigation component to include services menu with hover/mobile support
- Add menuDescription and menuOrder fields to service schema
- Update services page to use modern card layout with hero images
- Fix mobile navigation dropdown behavior and styling
- Remove service category grouping for unified display
- Update sanity queries to fetch hero images for service cards
- Add proper semantic HTML using <p> tags instead of headings in navigation
- Improve responsive design and viewport handling for mobile