### PR TITLE
feat: Add Who We Help pages to HTML and XML sitemaps

### DIFF
--- a/app/(site)/sitemap/page.tsx
+++ b/app/(site)/sitemap/page.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
 import Breadcrumb from "@/app/components/Breadcrumb";
 import PageHero from "@/app/components/PageHero";
-import { getProducts, getServices } from "@/sanity/sanity-utils";
+import { getProducts, getServices, getWhoWeHelps } from "@/sanity/sanity-utils";
 import { getProjects } from "@/sanity/sanity-utils";
 import { createClient } from "next-sanity";
 import { Product } from "@/types/Product";
 import { Project } from "@/types/project";
 import { Service } from "@/types/Service";
+import { WhoWeHelp } from "@/types/WhoWeHelp";
 
 type Page = {
   _id: string;
@@ -28,10 +29,11 @@ export default async function Sitemap() {
   ];
 
   // Fetch dynamic content from Sanity
-  const [products, projects, services, pages] = await Promise.all([
+  const [products, projects, services, whoWeHelps, pages] = await Promise.all([
     getProducts(),
     getProjects(),
     getServices(),
+    getWhoWeHelps(),
     client.fetch(`*[_type == "page" && defined(slug.current)] {
       _id,
       title,
@@ -69,6 +71,15 @@ export default async function Sitemap() {
               </Link>
               <Link href="/about" className="block text-emerald-600 hover:text-emerald-700 text-lg">
                 About Us
+              </Link>
+              <Link href="/products" className="block text-emerald-600 hover:text-emerald-700 text-lg">
+                Products
+              </Link>
+              <Link href="/services" className="block text-emerald-600 hover:text-emerald-700 text-lg">
+                Services
+              </Link>
+              <Link href="/who-we-help" className="block text-emerald-600 hover:text-emerald-700 text-lg">
+                Who We Help
               </Link>
               <Link href="/contact-us" className="block text-emerald-600 hover:text-emerald-700 text-lg">
                 Contact Us
@@ -127,6 +138,35 @@ export default async function Sitemap() {
                     </span>
                     <span className="flex-1">
                       {service.name}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Who We Help Section */}
+          {whoWeHelps && whoWeHelps.length > 0 && (
+            <div className="mb-16">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4">
+                Who We Help
+              </h2>
+              <p className="text-gray-600 mb-8">
+                Discover how we help different types of businesses and entrepreneurs bring their beauty vision to life.
+              </p>
+              
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-6 md:gap-y-4">
+                {whoWeHelps.map((whoWeHelp: WhoWeHelp) => (
+                  <Link 
+                    key={whoWeHelp._id}
+                    href={`/who-we-help/${whoWeHelp.slug}`} 
+                    className="flex items-start text-emerald-600 hover:text-emerald-700 text-lg group"
+                  >
+                    <span className="text-emerald-500 mr-3 mt-1 text-sm group-hover:text-emerald-600 transition-colors">
+                      •
+                    </span>
+                    <span className="flex-1">
+                      {whoWeHelp.name}
                     </span>
                   </Link>
                 ))}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -43,6 +43,16 @@ type SitemapService = {
   _updatedAt: string
 }
 
+type SitemapWhoWeHelp = {
+  _id: string
+  name: string
+  slug: string
+  _updatedAt: string
+  seo?: {
+    noIndex?: boolean
+  }
+}
+
 export async function GET() {
   try {
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.elixderm.com'
@@ -75,6 +85,12 @@ export async function GET() {
         lastModified: new Date().toISOString()
       },
       { 
+        url: '/who-we-help', 
+        changeFreq: 'weekly' as const, 
+        priority: 0.9,
+        lastModified: new Date().toISOString()
+      },
+      { 
         url: '/contact-us', 
         changeFreq: 'monthly' as const, 
         priority: 0.9,
@@ -99,7 +115,7 @@ export async function GET() {
     })
 
     // Fetch dynamic pages from Sanity
-    const [pages, projects, products, services] = await Promise.all([
+    const [pages, projects, products, services, whoWeHelps] = await Promise.all([
       // Pages
       client.fetch(`*[_type == "page" && defined(slug.current)] {
         _id,
@@ -127,6 +143,16 @@ export async function GET() {
         name,
         "slug": slug.current,
         _updatedAt
+      }`),
+      // Who We Help (only indexable pages)
+      client.fetch(`*[_type == "whoWeHelp" && defined(slug.current) && (!defined(seo.noIndex) || seo.noIndex != true)] {
+        _id,
+        name,
+        "slug": slug.current,
+        _updatedAt,
+        seo {
+          noIndex
+        }
       }`)
     ])
 
@@ -165,6 +191,16 @@ export async function GET() {
       sitemap.push({
         url: `${baseUrl}/services/${service.slug}`,
         lastModified: new Date(service._updatedAt).toISOString(),
+        changeFreq: 'weekly',
+        priority: 0.8
+      })
+    })
+
+    // Add who we help pages (only indexable ones)
+    whoWeHelps.forEach((whoWeHelp: SitemapWhoWeHelp) => {
+      sitemap.push({
+        url: `${baseUrl}/who-we-help/${whoWeHelp.slug}`,
+        lastModified: new Date(whoWeHelp._updatedAt).toISOString(),
         changeFreq: 'weekly',
         priority: 0.8
       })


### PR DESCRIPTION
- Add Who We Help section to HTML sitemap with proper categorization
- Include main /who-we-help page in main pages section
- Add individual Who We Help pages to XML sitemap with SEO filtering
- Only include indexable pages (exclude noIndex pages from XML sitemap)
- Set appropriate priority (0.8) and change frequency (weekly) for SEO
- Improve sitemap navigation with Products and Services main page links